### PR TITLE
Testing also with WebKit

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,7 +52,12 @@ jobs:
         PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./playwright.sh
 
   integration_test_with_latest_playwright:
-    name: Integration test (with latest playwright)
+    name: Integration test [${{ matrix.browser_type }}] (with latest playwright)
+    strategy:
+      matrix:
+        browser_type:
+          - chromium
+          - webkit
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
@@ -71,4 +76,5 @@ jobs:
     - run: bundle exec ruby development/generate_api.rb
     - run: xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration --profile 10
       env:
+        BROWSER: ${{ matrix.browser_type }}
         PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./node_modules/.bin/playwright

--- a/lib/playwright/channel_owners/webkit_browser.rb
+++ b/lib/playwright/channel_owners/webkit_browser.rb
@@ -2,7 +2,7 @@ require_relative './browser'
 
 module Playwright
   module ChannelOwners
-    class WebkitBrowser < Browser
+    class WebKitBrowser < Browser
     end
   end
 end

--- a/spec/integration/page/autowaiting_basic_spec.rb
+++ b/spec/integration/page/autowaiting_basic_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe 'autowaiting basic' do
 
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.click('a')
           messages << 'click'
         },
@@ -44,6 +45,7 @@ RSpec.describe 'autowaiting basic' do
 
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.click('a')
           messages << 'click'
         },
@@ -78,6 +80,7 @@ RSpec.describe 'autowaiting basic' do
 
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.click('input[type=submit]')
           messages << 'click'
         },
@@ -112,6 +115,7 @@ RSpec.describe 'autowaiting basic' do
 
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.click('input[type=submit]')
           messages << 'click'
         },
@@ -138,6 +142,7 @@ RSpec.describe 'autowaiting basic' do
     with_page do |page|
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.evaluate("window.location.href = \"#{server_cross_process_prefix}#{endpoint}\"")
           messages << 'evaluate'
         },
@@ -186,6 +191,7 @@ RSpec.describe 'autowaiting basic' do
 
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.evaluate('window.location.reload()')
           messages << 'evaluate'
         },
@@ -219,6 +225,7 @@ RSpec.describe 'autowaiting basic' do
       frame = page.frame({name: 'target'})
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.click('a')
           messages << 'click'
         },
@@ -272,6 +279,7 @@ RSpec.describe 'autowaiting basic' do
 
       promises = [
         Concurrent::Promises.future {
+          sleep 0.5
           page.click('a')
           page.wait_for_load_state(state: 'load')
           messages << 'clickload'

--- a/spec/integration/page/basic_spec.rb
+++ b/spec/integration/page/basic_spec.rb
@@ -215,10 +215,11 @@ RSpec.describe Playwright::Page do
     engine, browser = parts[4].split(' ')
     expect(browser).to start_with('Safari')
 
-    # if (isChromium)
-    #   expect(engine).to include('Chrome/')
-    # else
-    expect(engine).to start_with('Version/')
+    if chromium?
+      expect(engine).to include('Chrome/')
+    else
+      expect(engine).to start_with('Version/')
+    end
   end
 
   it 'page.press should work', sinatra: true do

--- a/spec/integration/page/basic_spec.rb
+++ b/spec/integration/page/basic_spec.rb
@@ -216,9 +216,9 @@ RSpec.describe Playwright::Page do
     expect(browser).to start_with('Safari')
 
     # if (isChromium)
-    expect(engine).to include('Chrome/')
+    #   expect(engine).to include('Chrome/')
     # else
-    #   expect(engine.startsWith('Version/')).toBe(true);
+    expect(engine).to start_with('Version/')
   end
 
   it 'page.press should work', sinatra: true do

--- a/spec/integration/spec_helper_spec.rb
+++ b/spec/integration/spec_helper_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+RSpec.describe 'spec_helper' do
+  it 'browser_type', skip: ENV['BROWSER'].nil? do
+    expect(chromium?).to eq(ENV['BROWSER'] == 'chromium')
+    expect(webkit?).to eq(ENV['BROWSER'] == 'webkit')
+    expect(firefox?).to eq(ENV['BROWSER'] == 'firefox')
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -26,9 +26,16 @@ RSpec.configure do |config|
     metadata[:type] = :integration
   end
 
+  browser_type = :chromium
+  BROWSER_TYPES = %i(chromium webkit firefox)
+  if BROWSER_TYPES.include?(ENV['BROWSER']&.to_sym)
+    browser_type = ENV['BROWSER'].to_sym
+  end
+
   config.around(:each, type: :integration) do |example|
+    @playwright_browser_type = browser_type
     Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
-      playwright.webkit.launch do |browser|
+      playwright.send(@playwright_browser_type).launch do |browser|
         @playwright_browser = browser
         example.run
       end
@@ -63,6 +70,9 @@ RSpec.configure do |config|
         page.close
       end
     end
+  end
+  BROWSER_TYPES.each do |type|
+    IntegrationTestCaseMethods.define_method("#{type}?") { @playwright_browser_type == type }
   end
   config.include IntegrationTestCaseMethods, type: :integration
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -28,7 +28,7 @@ RSpec.configure do |config|
 
   config.around(:each, type: :integration) do |example|
     Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
-      playwright.chromium.launch do |browser|
+      playwright.webkit.launch do |browser|
         @playwright_browser = browser
         example.run
       end


### PR DESCRIPTION
Now spec_helper detect target browser by 'BROWSER' environment variables.
Also, `chromium?` `firefox?` `webkit?` helper methods are defined.