### PR TITLE
Implement Android Browser automation

### DIFF
--- a/development/generate_api.rb
+++ b/development/generate_api.rb
@@ -27,6 +27,10 @@ ALL_TYPES = %w[
     BrowserType
     Playwright
 ]
+EXPERIMENTAL = %w[
+  Android
+  AndroidDevice
+]
 INPUT_TYPES = %w[
   Keyboard
   Mouse
@@ -53,7 +57,7 @@ if $0 == __FILE__
     f.write("# API coverages\n")
   end
 
-  ALL_TYPES.each do |class_name|
+  (ALL_TYPES + EXPERIMENTAL).each do |class_name|
     doc_json = api_json.find { |json| json['name'] == class_name }
     doc = doc_json ? ClassDoc.new(doc_json, root: api_json) : nil
 

--- a/lib/playwright/channel_owners/android.rb
+++ b/lib/playwright/channel_owners/android.rb
@@ -1,3 +1,12 @@
 module Playwright
-  define_channel_owner :Android
+  define_channel_owner :Android do
+    def after_initialize
+      @timeout_settings = TimeoutSettings.new
+    end
+
+    def devices
+      resp = @channel.send_message_to_server('devices')
+      resp.map { |device| ChannelOwners::AndroidDevice.from(device) }
+    end
+  end
 end

--- a/lib/playwright/channel_owners/android_device.rb
+++ b/lib/playwright/channel_owners/android_device.rb
@@ -1,0 +1,93 @@
+module Playwright
+  define_channel_owner :AndroidDevice do
+    include Utils::PrepareBrowserContextOptions
+
+    def serial
+      @initializer['serial']
+    end
+
+    def model
+      @initializer['model']
+    end
+
+    def shell(command)
+      resp = @channel.send_message_to_server('shell', command: command)
+      Base64.strict_decode64(resp)
+    end
+
+    def close
+      @channel.send_message_to_server('close')
+      emit(Events::AndroidDevice::Close)
+    end
+
+    def launch_browser(
+          pkg: nil,
+          acceptDownloads: nil,
+          bypassCSP: nil,
+          colorScheme: nil,
+          deviceScaleFactor: nil,
+          extraHTTPHeaders: nil,
+          geolocation: nil,
+          hasTouch: nil,
+          httpCredentials: nil,
+          ignoreHTTPSErrors: nil,
+          isMobile: nil,
+          javaScriptEnabled: nil,
+          locale: nil,
+          logger: nil,
+          offline: nil,
+          permissions: nil,
+          proxy: nil,
+          recordHar: nil,
+          recordVideo: nil,
+          storageState: nil,
+          timezoneId: nil,
+          userAgent: nil,
+          videoSize: nil,
+          videosPath: nil,
+          viewport: nil,
+          &block)
+      params = {
+        pkg: pkg,
+        acceptDownloads: acceptDownloads,
+        bypassCSP: bypassCSP,
+        colorScheme: colorScheme,
+        deviceScaleFactor: deviceScaleFactor,
+        extraHTTPHeaders: extraHTTPHeaders,
+        geolocation: geolocation,
+        hasTouch: hasTouch,
+        httpCredentials: httpCredentials,
+        ignoreHTTPSErrors: ignoreHTTPSErrors,
+        isMobile: isMobile,
+        javaScriptEnabled: javaScriptEnabled,
+        locale: locale,
+        logger: logger,
+        offline: offline,
+        permissions: permissions,
+        proxy: proxy,
+        recordHar: recordHar,
+        recordVideo: recordVideo,
+        storageState: storageState,
+        timezoneId: timezoneId,
+        userAgent: userAgent,
+        videoSize: videoSize,
+        videosPath: videosPath,
+        viewport: viewport,
+      }.compact
+      prepare_browser_context_options(params)
+
+      resp = @channel.send_message_to_server('launchBrowser', params)
+      context = ChannelOwners::BrowserContext.from(resp)
+
+      if block
+        begin
+          block.call(context)
+        ensure
+          context.close
+        end
+      else
+        context
+      end
+    end
+  end
+end

--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -180,7 +180,7 @@ module Playwright
         timeout: timeout,
       }.compact
       encoded_binary = @channel.send_message_to_server('screenshot', params)
-      decoded_binary = Base64.decode64(encoded_binary)
+      decoded_binary = Base64.strict_decode64(encoded_binary)
       if path
         File.open(path, 'wb') do |f|
           f.write(decoded_binary)

--- a/lib/playwright/utils.rb
+++ b/lib/playwright/utils.rb
@@ -1,5 +1,23 @@
 module Playwright
   module Utils
+    module PrepareBrowserContextOptions
+      # @see https://github.com/microsoft/playwright/blob/5a2cfdbd47ed3c3deff77bb73e5fac34241f649d/src/client/browserContext.ts#L265
+      private def prepare_browser_context_options(params)
+        if params[:viewport] == 0
+          params.delete(:viewport)
+          params[:noDefaultViewport] = true
+        end
+        if params[:extraHTTPHeaders]
+          # TODO
+        end
+        if params[:storageState].is_a?(String)
+          params[:storageState] = JSON.parse(File.read(params[:storageState]))
+        end
+
+        params
+      end
+    end
+
     module Errors
       module SafeCloseError
         # @param err [Exception]


### PR DESCRIPTION
ref: https://github.com/microsoft/playwright/issues/1122, https://www.npmjs.com/package/playwright-android

Android automation components are already merged into playwright server, and available via playwright driver. So we can play with it also in Ruby :)

```ruby
require 'playwright'

Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
  devices = playwright.android.devices
  unless devices.empty?
    device = devices.last
    begin
      puts "Model: #{device.model}"
      puts "Serial: #{device.serial}"
      puts device.shell('ls /system')

      device.launch_browser do |context|
        page = context.pages.first
        page.goto('https://github.com/YusukeIwaki')
        page.click('header button')
        page.click('input[name="q"]')
        page.keyboard.type_text('puppeteer')
        page.expect_navigation {
          page.keyboard.press('Enter')
        }
        page.screenshot(path: 'YusukeIwaki.android.png')
      end
    ensure
      device.close
    end
  end
end
```

This code allows us to take a screenshot of GitHub page with Android Chrome browser.

![android-browser](https://user-images.githubusercontent.com/11763113/106615177-8467a800-65af-11eb-94d9-c56e71487e78.gif)
