### PR TITLE
fix flaky spec

### DIFF
--- a/spec/integration/page/basic_spec.rb
+++ b/spec/integration/page/basic_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Playwright::Page do
   it 'should reject all promises when page is closed' do
     with_page do |page|
       never_resolved_promise = Concurrent::Promises.future { page.evaluate('() => new Promise(r => {})') }
+      sleep 0.5
       page.close
       expect { never_resolved_promise.value! }.to raise_error(/Protocol error/)
     end


### PR DESCRIPTION
```
RECV>{"guid"=>"BrowserContext@7949e9bc91d30eee1e79fecdc8b1cee7", "method"=>"__create__", "params"=>{"type"=>"Page", "initializer"=>{"mainFrame"=>{"guid"=>"Frame@e062d6083c53be0ce7d9ea1721382b83"}, "viewportSize"=>{"width"=>1280, "height"=>720}, "isClosed"=>false}, "guid"=>"Page@33bfaaf2c3063e5315ef21c251871617"}}
RECV>{"guid"=>"BrowserContext@7949e9bc91d30eee1e79fecdc8b1cee7", "method"=>"page", "params"=>{"page"=>{"guid"=>"Page@33bfaaf2c3063e5315ef21c251871617"}}}
RECV>{"id"=>3, "result"=>{"page"=>{"guid"=>"Page@33bfaaf2c3063e5315ef21c251871617"}}}
SEND>{:id=>4, :guid=>"Page@33bfaaf2c3063e5315ef21c251871617", :method=>"close", :params=>{}}
SEND>{:id=>5, :guid=>"Frame@e062d6083c53be0ce7d9ea1721382b83", :method=>"evaluateExpression", :params=>{:expression=>"() => new Promise(r => {})", :isFunction=>true, :arg=>{:value=>{:v=>"undefined"}, :handles=>[]}}}
undefined:1
```

This is caused by connection reset during sending a message.
So prevent closing during page.evaluate