### PR TITLE
implement AndroidDevice#tree, info, tap_on

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,41 @@ end
 
 ![android-browser](https://user-images.githubusercontent.com/11763113/106615177-8467a800-65af-11eb-94d9-c56e71487e78.gif)
 
+### Android native automation
+
+We have to download android-driver for Playwright in advance.
+
+```
+wget https://github.com/microsoft/playwright/raw/master/bin/android-driver-target.apk -O /path/to/playwright-driver/package/bin/android-driver-target.apk
+wget https://github.com/microsoft/playwright/raw/master/bin/android-driver.apk -O /path/to/playwright-driver/package/bin/android-driver.apk
+```
+
+(If you downloaded Playwright via npm, replace `/path/to/playwright-driver/package/` with `./node_modules/playwright/` above.)
+
+```ruby
+require 'playwright'
+
+Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
+  devices = playwright.android.devices
+  unless devices.empty?
+    device = devices.last
+    begin
+      device.shell('input keyevent POWER')
+      device.shell('input keyevent POWER')
+      device.shell('input keyevent 82')
+      sleep 1
+      device.shell('cmd statusbar expand-notifications')
+
+      # pp device.tree
+      # pp device.info(res: 'com.android.systemui:id/clock')
+      device.tap_on(res: 'com.android.systemui:id/clock')
+    ensure
+      device.close
+    end
+  end
+end
+
+```
 
 ## License
 

--- a/development/generate_api.rb
+++ b/development/generate_api.rb
@@ -30,8 +30,10 @@ ALL_TYPES = %w[
 EXPERIMENTAL = %w[
   Android
   AndroidDevice
+  AndroidInput
 ]
 INPUT_TYPES = %w[
+  AndroidInput
   Keyboard
   Mouse
   Touchscreen
@@ -66,7 +68,11 @@ if $0 == __FILE__
         klass = Playwright::InputTypes.const_get(class_name) rescue nil
 
         if klass
-          ImplementedInputTypeClass.new(doc, klass, inflector)
+          if doc
+            ImplementedInputTypeClassWithDoc.new(doc, klass, inflector)
+          else
+            ImplementedInputTypeClassWithoutDoc.new(klass, inflector)
+          end
         else
           # UnimplementedClassWithDoc.new(doc, inflector)
           raise "#{class_name} Not Implemented!!"

--- a/development/generate_api/views/implemented_input_type_class_with_doc.rb
+++ b/development/generate_api/views/implemented_input_type_class_with_doc.rb
@@ -1,4 +1,4 @@
-class ImplementedInputTypeClass
+class ImplementedInputTypeClassWithDoc
   # @param doc [Doc]
   # @param klass [Class]
   # @param inflector [Dry::Inflector]

--- a/development/generate_api/views/implemented_input_type_class_without_doc.rb
+++ b/development/generate_api/views/implemented_input_type_class_without_doc.rb
@@ -1,0 +1,44 @@
+class ImplementedInputTypeClassWithoutDoc
+  # @param klass [Class]
+  # @param inflector [Dry::Inflector]
+  def initialize(klass, inflector)
+    @klass = klass
+    @inflector = inflector
+  end
+
+  # @returns Enumerable<String>
+  def lines
+    Enumerator.new do |data|
+      data << 'module Playwright'
+      data << '  # @nodoc'
+      data << "  class #{class_name} < PlaywrightApi"
+      method_lines.each(&data)
+      data << '  end'
+      data << 'end'
+    end
+  end
+
+  def api_coverages
+    Enumerator.new do |data|
+      # nothing
+    end
+  end
+
+  private
+
+  # @returns [String]
+  def class_name
+    @inflector.demodulize(@klass)
+  end
+
+  def method_lines
+    Enumerator.new do |data|
+      (@klass.public_instance_methods - @klass.superclass.public_instance_methods).each do |method_sym|
+        method = @klass.public_instance_method(method_sym)
+
+        data << '' # insert blank line before definition.
+        ImplementedMethodWithoutDoc.new(method, @inflector).lines.each(&data)
+      end
+    end
+  end
+end

--- a/lib/playwright/input_types/android_input.rb
+++ b/lib/playwright/input_types/android_input.rb
@@ -1,0 +1,19 @@
+module Playwright
+  define_input_type :AndroidInput do
+    def type(text)
+      @channel.send_message_to_server('inputType', text: text)
+    end
+
+    def press(key)
+      @channel.send_message_to_server('inputPress', key: key)
+    end
+
+    def tap_point(point)
+      @channel.send_message_to_server('inputTap', point: point)
+    end
+
+    def drag(from, to, steps)
+      @channel.send_message_to_server('inputDrag', from: from, to: to, steps: steps)
+    end
+  end
+end


### PR DESCRIPTION
Enjoy with native-Android automation :)

```ruby
require 'playwright'

Playwright.create(playwright_cli_executable_path: './node_modules/.bin/playwright') do |playwright|
  devices = playwright.android.devices
  unless devices.empty?
    device = devices.last
    begin
      device.shell('input keyevent POWER')
      device.shell('input keyevent POWER')
      device.shell('input keyevent 82')
      sleep 1
      device.shell('cmd statusbar expand-notifications')
      device.tap_on(res: 'com.android.systemui:id/clock')
    ensure
      device.close
    end
  end
end
```

![playwright-ruby-native-android](https://user-images.githubusercontent.com/11763113/107253885-1ffa8c00-6a7a-11eb-86e3-012156c84d45.gif)
