### PR TITLE
Migrate classes/methods code generation with Python's API specs

### DIFF
--- a/development/generate_api/models/arg_doc.rb
+++ b/development/generate_api/models/arg_doc.rb
@@ -2,16 +2,16 @@ require_relative './doc'
 
 class ArgDoc < Doc
   def type_signature
-    @json['type']['name']
+    json_with_python_override['type']['name']
   end
 
   def required?
-    @json['required']
+    json_with_python_override['required']
   end
 
   def properties
-    @json['type']['properties']&.
+    json_with_python_override['type']['properties']&.
       map { |json| ArgDoc.new(json) }.
-      reject { |doc| doc.langs.only_python? }
+      reject { |doc| doc.langs.not_for_python? }
   end
 end

--- a/development/generate_api/models/class_doc.rb
+++ b/development/generate_api/models/class_doc.rb
@@ -17,23 +17,23 @@ class ClassDoc < Doc
   end
 
   def method_docs
-    @json['members'].
+    json_with_python_override['members'].
       select { |json| json['kind'] == 'method' }.
       map{ |json| MethodDoc.new(json) }.
-      reject { |doc| doc.langs.only_python? }
+      reject { |doc| doc.langs.not_for_python? }
   end
 
   def event_docs
-    @json['members'].
+    json_with_python_override['members'].
       select { |json| json['kind'] == 'event' }.
       map{ |json| MethodDoc.new(json) }.
-      reject { |doc| doc.langs.only_python? }
+      reject { |doc| doc.langs.not_for_python? }
   end
 
   def property_docs
-    @json['members'].
+    json_with_python_override['members'].
       select { |json| json['kind'] == 'property' }.
       map{ |json| MethodDoc.new(json) }.
-      reject { |doc| doc.langs.only_python? }
+      reject { |doc| doc.langs.not_for_python? }
   end
 end

--- a/development/generate_api/models/doc.rb
+++ b/development/generate_api/models/doc.rb
@@ -5,7 +5,7 @@ class Doc
 
   # @returns [String]
   def kind
-    @json['kind']
+    json_with_python_override['kind']
   end
 
   # @returns [String]
@@ -15,7 +15,11 @@ class Doc
 
   # @returns [String]
   def comment
-    @json['comment']
+    json_with_python_override['comment']
+  end
+
+  private def json_with_python_override
+    langs.overrides_for_python || @json
   end
 
   class Langs
@@ -23,12 +27,16 @@ class Doc
       @json = json
     end
 
-    def only_js?
-      @json['only'] && @json['only'].include?('js')
+    def not_for_python?
+      @json['only'] && !@json['only'].include?('python')
     end
 
     def only_python?
-      @json['only'] && @json['only'].include?('python')
+      @json['only'] && @json['only'].include?('python') && !@json['only'].include?('js')
+    end
+
+    def overrides_for_python
+      @json.dig('overrides', 'python')
     end
 
     def alias_for_python

--- a/development/generate_api/models/event_doc.rb
+++ b/development/generate_api/models/event_doc.rb
@@ -2,6 +2,6 @@ require_relative './doc'
 
 class EventDoc < Doc
   def callback_type_signature
-    @json['type']['name']
+    json_with_python_override['type']['name']
   end
 end

--- a/development/generate_api/models/method_doc.rb
+++ b/development/generate_api/models/method_doc.rb
@@ -3,12 +3,12 @@ require_relative './doc'
 class MethodDoc < Doc
   # @returns [String]
   def return_type_signature
-    @json['type']['name']
+    json_with_python_override['type']['name']
   end
 
   def arg_docs
-    @json['args'].
+    json_with_python_override['args'].
       map { |json| ArgDoc.new(json) }.
-      reject { |doc| doc.langs.only_python? }
+      reject { |doc| doc.langs.not_for_python? }
   end
 end

--- a/development/generate_api/models/property_doc.rb
+++ b/development/generate_api/models/property_doc.rb
@@ -2,6 +2,6 @@ require_relative './doc'
 
 class PropertyDoc < Doc
   def type_signature
-    @json['type']['name']
+    json_with_python_override['type']['name']
   end
 end

--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -9,6 +9,7 @@
 * method
 * post_data
 * post_data_buffer
+* post_data_json
 * redirected_from
 * redirected_to
 * resource_type
@@ -22,6 +23,7 @@
 * ~~finished~~
 * ~~frame~~
 * ~~headers~~
+* ~~json~~
 * ~~ok~~
 * ~~request~~
 * ~~status~~
@@ -40,6 +42,8 @@
 
 * ~~closed?~~
 * ~~url~~
+* ~~expect_event~~
+* ~~wait_for_event~~
 
 ## Keyboard
 
@@ -197,7 +201,6 @@
 
 ## Download
 
-* ~~create_read_stream~~
 * delete
 * failure
 * path
@@ -273,6 +276,7 @@
 * url
 * ~~video~~
 * viewport_size
+* expect_event
 * wait_for_function
 * wait_for_load_state
 * expect_navigation
@@ -281,8 +285,13 @@
 * wait_for_selector
 * ~~wait_for_timeout~~
 * ~~workers~~
+* ~~expect_download~~
+* ~~expect_popup~~
+* ~~expect_worker~~
+* ~~expect_console_message~~
+* ~~expect_file_chooser~~
+* ~~wait_for_event~~
 * accessibility
-* ~~coverage~~
 * keyboard
 * mouse
 * touchscreen
@@ -306,10 +315,12 @@
 * ~~set_default_timeout~~
 * ~~set_extra_http_headers~~
 * ~~set_geolocation~~
-* ~~set_http_credentials~~
 * ~~set_offline~~
 * ~~storage_state~~
 * ~~unroute~~
+* ~~expect_event~~
+* ~~expect_page~~
+* ~~wait_for_event~~
 
 ## ~~CDPSession~~
 
@@ -333,19 +344,16 @@
 
 ## BrowserType
 
-* ~~connect~~
 * executable_path
 * launch
 * ~~launch_persistent_context~~
-* ~~launch_server~~
 * name
 
 ## Playwright
 
-* ~~close~~
+* ~~stop~~
 * chromium
 * devices
-* ~~errors~~
 * firefox
 * ~~selectors~~
 * webkit

--- a/lib/playwright/channel_owner.rb
+++ b/lib/playwright/channel_owner.rb
@@ -59,16 +59,14 @@ module Playwright
       "#<#{@guid}>"
     end
 
-    private
-
-    def after_initialize
+    private def after_initialize
     end
 
-    def update_object_from_child(guid, child)
+    private def update_object_from_child(guid, child)
       @objects[guid] = child
     end
 
-    def delete_object_from_child(guid)
+    private def delete_object_from_child(guid)
       @objects.delete(guid)
     end
   end

--- a/lib/playwright/channel_owners/android.rb
+++ b/lib/playwright/channel_owners/android.rb
@@ -1,6 +1,6 @@
 module Playwright
   define_channel_owner :Android do
-    def after_initialize
+    private def after_initialize
       @timeout_settings = TimeoutSettings.new
     end
 

--- a/lib/playwright/channel_owners/android_device.rb
+++ b/lib/playwright/channel_owners/android_device.rb
@@ -2,7 +2,7 @@ module Playwright
   define_channel_owner :AndroidDevice do
     include Utils::PrepareBrowserContextOptions
 
-    def after_initialize
+    private def after_initialize
       @input = AndroidInputImpl.new(@channel)
     end
 
@@ -104,17 +104,17 @@ module Playwright
           isMobile: nil,
           javaScriptEnabled: nil,
           locale: nil,
-          logger: nil,
+          noViewport: nil,
           offline: nil,
           permissions: nil,
           proxy: nil,
-          recordHar: nil,
-          recordVideo: nil,
+          record_har_omit_content: nil,
+          record_har_path: nil,
+          record_video_dir: nil,
+          record_video_size: nil,
           storageState: nil,
           timezoneId: nil,
           userAgent: nil,
-          videoSize: nil,
-          videosPath: nil,
           viewport: nil,
           &block)
       params = {
@@ -131,17 +131,17 @@ module Playwright
         isMobile: isMobile,
         javaScriptEnabled: javaScriptEnabled,
         locale: locale,
-        logger: logger,
+        noViewport: noViewport,
         offline: offline,
         permissions: permissions,
         proxy: proxy,
-        recordHar: recordHar,
-        recordVideo: recordVideo,
+        record_har_omit_content: record_har_omit_content,
+        record_har_path: record_har_path,
+        record_video_dir: record_video_dir,
+        record_video_size: record_video_size,
         storageState: storageState,
         timezoneId: timezoneId,
         userAgent: userAgent,
-        videoSize: videoSize,
-        videosPath: videosPath,
         viewport: viewport,
       }.compact
       prepare_browser_context_options(params)

--- a/lib/playwright/channel_owners/browser.rb
+++ b/lib/playwright/channel_owners/browser.rb
@@ -4,7 +4,7 @@ module Playwright
     include Utils::Errors::SafeCloseError
     include Utils::PrepareBrowserContextOptions
 
-    def after_initialize
+    private def after_initialize
       @contexts = Set.new
       @channel.on('close', method(:on_close))
     end

--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -4,7 +4,7 @@ module Playwright
     include Utils::Errors::SafeCloseError
     attr_writer :browser, :owner_page, :options
 
-    def after_initialize
+    private def after_initialize
       @pages = Set.new
 
       @channel.once('close', ->(_) { on_close })

--- a/lib/playwright/channel_owners/element_handle.rb
+++ b/lib/playwright/channel_owners/element_handle.rb
@@ -136,8 +136,19 @@ module Playwright
         nil
       end
 
-      def select_option(values, noWaitAfter: nil, timeout: nil)
-        base_params = SelectOptionValues.new(values).as_params
+      def select_option(
+            element: nil,
+            index: nil,
+            value: nil,
+            label: nil,
+            noWaitAfter: nil,
+            timeout: nil)
+        base_params = SelectOptionValues.new(
+          element: element,
+          index: index,
+          value: value,
+          label: label,
+        ).as_params
         params = base_params + { noWaitAfter: noWaitAfter, timeout: timeout }.compact
         @channel.send_message_to_server('selectOption', params)
 

--- a/lib/playwright/channel_owners/frame.rb
+++ b/lib/playwright/channel_owners/frame.rb
@@ -1,7 +1,7 @@
 module Playwright
   # @ref https://github.com/microsoft/playwright-python/blob/master/playwright/_impl/_frame.py
   define_channel_owner :Frame do
-    def after_initialize
+    private def after_initialize
       if @initializer['parentFrame']
         @parent_frame = ChannelOwners::Frame.from(@initializer['parentFrame'])
         @parent_frame.send(:append_child_frame_from_child, self)
@@ -398,8 +398,20 @@ module Playwright
       nil
     end
 
-    def select_option(selector, values, noWaitAfter: nil, timeout: nil)
-      base_params = SelectOptionValues.new(values).as_params
+    def select_option(
+          selector,
+          element: nil,
+          index: nil,
+          value: nil,
+          label: nil,
+          noWaitAfter: nil,
+          timeout: nil)
+      base_params = SelectOptionValues.new(
+        element: element,
+        index: index,
+        value: value,
+        label: label,
+      ).as_params
       params = base_params + { selector: selector, noWaitAfter: noWaitAfter, timeout: timeout }.compact
       @channel.send_message_to_server('selectOption', params)
 

--- a/lib/playwright/channel_owners/js_handle.rb
+++ b/lib/playwright/channel_owners/js_handle.rb
@@ -1,6 +1,6 @@
 module Playwright
   define_channel_owner :JSHandle do
-    def after_initialize
+    private def after_initialize
       @preview = @initializer['preview']
       @channel.on('previewUpdated', method(:on_preview_updated))
     end

--- a/lib/playwright/channel_owners/request.rb
+++ b/lib/playwright/channel_owners/request.rb
@@ -3,7 +3,7 @@ require 'base64'
 module Playwright
   # @ref https://github.com/microsoft/playwright-python/blob/master/playwright/_impl/_network.py
   define_channel_owner :Request do
-    def after_initialize
+    private def after_initialize
       @redirected_from = ChannelOwners::Request.from_nullable(@initializer['redirectedFrom'])
       @redirected_from&.send(:update_redirected_to, self)
       @timing = {

--- a/lib/playwright/select_option_values.rb
+++ b/lib/playwright/select_option_values.rb
@@ -1,7 +1,18 @@
 module Playwright
   class SelectOptionValues
-    def initialize(values)
-      @params = convert(values)
+    def initialize(element: nil, index: nil, value: nil, label: nil)
+      @params =
+        if element
+          convert(elmeent)
+        elsif index
+          convert(index)
+        elsif value
+          convert(value)
+        elsif label
+          convert(label)
+        else
+          {}
+        end
     end
 
     # @return [Hash]
@@ -10,8 +21,7 @@ module Playwright
     end
 
     private def convert(values)
-      return {} unless values
-      return convert([values]) unless values.is_a?('Array')
+      return convert([values]) unless values.is_a?(Enumerable)
       return {} if values.empty?
       values.each_with_index do |value, index|
         unless values

--- a/lib/playwright/utils.rb
+++ b/lib/playwright/utils.rb
@@ -3,8 +3,8 @@ module Playwright
     module PrepareBrowserContextOptions
       # @see https://github.com/microsoft/playwright/blob/5a2cfdbd47ed3c3deff77bb73e5fac34241f649d/src/client/browserContext.ts#L265
       private def prepare_browser_context_options(params)
-        if params[:viewport] == 0
-          params.delete(:viewport)
+        if params[:noViewport] == 0
+          params.delete(:noViewport)
           params[:noDefaultViewport] = true
         end
         if params[:extraHTTPHeaders]

--- a/spec/development/generate_api/views/implemented_class_with_doc_spec.rb
+++ b/spec/development/generate_api/views/implemented_class_with_doc_spec.rb
@@ -75,17 +75,69 @@ RSpec.describe 'ImplementedClassWithDoc' do
     end
   end
 
+  def json_type(name)
+    { 'name' => name }
+  end
+
+  def json_overrides(python: nil, js: nil)
+    { 'python' => python, 'js' => js }.compact
+  end
+
+  def json_langs(only: nil, overrides: {})
+    only = [only] if only && !only.is_a?(Array)
+
+    { 'only' => only, 'overrides' => overrides }.compact
+  end
+
+  def json_method(name, args = [], langs: {}, type: nil)
+    {
+      'kind' => 'method',
+      'langs' => langs,
+      'name' => name,
+      'type' => type || json_type('number'),
+      'required' => true,
+      'args' => args,
+    }
+  end
+
+  def json_arg(name, type, required: false, langs: {})
+    {
+      'kind' => 'property',
+      'langs' => langs,
+      'name' => name,
+      'required' => required,
+    }
+  end
+
+  def required_arg(name, type, langs: {})
+    json_arg(name, type, langs: langs, required: true)
+  end
+
+  def optional_arg(name, type, langs: {})
+    json_arg(name, type, langs: langs, required: false)
+  end
+
+  def object_arg(name, properties, langs: {}, required: false)
+    {
+      'kind' => 'property',
+      'langs' => langs,
+      'name' => name,
+      'type' => {
+        'name' => 'Object',
+        'properties' => properties,
+      },
+      'required' => required,
+    }
+  end
+
+  def optional_kwarg(name, properties, langs: {})
+    object_arg(name, properties, langs: langs, required: false)
+  end
+
   describe 'implemented and documented method' do
     context 'without arguments' do
       before {
-        api_json_hogehoge['members'] << {
-          'kind' => 'method',
-          'langs' => {},
-          'name' => 'awesomeCalc',
-          'type' => { 'name' => 'number' },
-          'required' => true,
-          'args' => [],
-        }
+        api_json_hogehoge['members'] << json_method('awesomeCalc')
       }
       let(:klass) do
         Class.new do
@@ -102,58 +154,14 @@ RSpec.describe 'ImplementedClassWithDoc' do
 
     context 'with arguments' do
       before {
-        api_json_hogehoge['members'] << {
-          'kind' => 'method',
-          'langs' => {},
-          'name' => 'awesomeCalc',
-          'type' => { 'name' => 'number' },
-          'required' => true,
-          'args' => [
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => 'a',
-              'type' => { 'name' => 'number' },
-              'required' => true,
-            },
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => 'options',
-              'type' => {
-                'name' => 'Object',
-                'properties' => [
-                  {
-                    'kind' => 'property',
-                    'langs' => {
-                      'only' => ['js'],
-                    },
-                    'name' => 'b',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {
-                      'only' => ['python'],
-                    },
-                    'name' => 'bOnlyForPython',
-                    'type' => { 'name' => 'number' },
-                    'required' => true,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {},
-                    'name' => 'c',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                ],
-              },
-              'required' => false,
-            },
-          ],
-        }
+        api_json_hogehoge['members'] << json_method('awesomeCalc', [
+          required_arg('a', json_type('number')),
+          optional_kwarg('options', [
+            optional_arg('b', json_type('number'), langs: json_langs(only: %w(js java))),
+            optional_arg('bOnlyForPython', json_type('number'), langs: json_langs(only: 'python')),
+            optional_arg('c', json_type('number')),
+          ])
+        ])
       }
       let(:klass) do
         Class.new do
@@ -164,78 +172,67 @@ RSpec.describe 'ImplementedClassWithDoc' do
       end
 
       it 'should generate a method with argument, without block' do
-        is_expected.to include("def awesome_calc(a, b: nil, c: nil)\n")
+        is_expected.to include("def awesome_calc(a, bOnlyForPython: nil, c: nil)\n")
+      end
+    end
+
+    context 'with options and python-only optional parameters' do
+      before {
+        api_json_hogehoge['members'] << json_method('awesomeCalc', [
+          required_arg('values', json_type('number'), langs: json_langs(only: %w(js java))),
+          optional_kwarg('options', [
+            optional_arg('ruby', json_type('number')),
+          ]),
+          optional_arg('python', json_type('number'), langs: json_langs(only: 'python')),
+        ])
+      }
+      let(:klass) do
+        Class.new do
+          def awesome_calc(ruby: nil, python: nil)
+          end
+        end
+      end
+
+      it 'should generate a method with argument, without block' do
+        is_expected.to include("def awesome_calc(python: nil, ruby: nil)\n")
+      end
+    end
+
+    context 'with overrides' do
+      before {
+        api_json_hogehoge['members'] << json_method('awesomeCalc', [
+          required_arg('values', json_type('number'), langs: json_langs(
+            overrides: json_overrides(
+              python: optional_arg('values', json_type('number'), langs: json_langs(only: 'python')),
+            ),
+          )),
+          optional_arg('python', json_type('number'), langs: json_langs(only: 'python')),
+        ])
+      }
+      let(:klass) do
+        Class.new do
+          def awesome_calc(values: nil, python: nil)
+          end
+        end
+      end
+
+      it 'should generate a method with argument, without block' do
+        is_expected.to include("def awesome_calc(python: nil, values: nil)\n")
       end
     end
 
     context 'with arguments size >= 4' do
       before {
-        api_json_hogehoge['members'] << {
-          'kind' => 'method',
-          'langs' => {},
-          'name' => 'awesomeCalc',
-          'type' => { 'name' => 'number' },
-          'required' => true,
-          'args' => [
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => 'a',
-              'type' => { 'name' => 'number' },
-              'required' => true,
-            },
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => 'options',
-              'type' => {
-                'name' => 'Object',
-                'properties' => [
-                  {
-                    'kind' => 'property',
-                    'langs' => {
-                      'only' => ['js'],
-                    },
-                    'name' => 'b',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {
-                      'only' => ['python'],
-                    },
-                    'name' => 'bOnlyForPython',
-                    'type' => { 'name' => 'number' },
-                    'required' => true,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {},
-                    'name' => 'c',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {},
-                    'name' => 'd',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {},
-                    'name' => 'e',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                ],
-              },
-              'required' => false,
-            },
-          ],
-        }
+        api_json_hogehoge['members'] << json_method('awesomeCalc', [
+          required_arg('a', json_type('number')),
+          optional_kwarg('options', [
+            optional_arg('b', json_type('number'), langs: json_langs(only: %w(js java))),
+            optional_arg('bOnlyForPython', json_type('number'), langs: json_langs(only: 'python')),
+            optional_arg('c', json_type('number')),
+            optional_arg('d', json_type('number')),
+            optional_arg('e', json_type('number')),
+          ])
+        ])
       }
       let(:klass) do
         Class.new do
@@ -252,14 +249,7 @@ RSpec.describe 'ImplementedClassWithDoc' do
 
     context 'without arguments, with explicit block parameter' do
       before {
-        api_json_hogehoge['members'] << {
-          'kind' => 'method',
-          'langs' => {},
-          'name' => 'awesomeCalc',
-          'type' => { 'name' => 'number' },
-          'required' => true,
-          'args' => [],
-        }
+        api_json_hogehoge['members'] << json_method('awesomeCalc')
       }
       let(:klass) do
         Class.new do
@@ -276,58 +266,14 @@ RSpec.describe 'ImplementedClassWithDoc' do
 
     context 'with arguments, with explicit block parameter' do
       before {
-        api_json_hogehoge['members'] << {
-          'kind' => 'method',
-          'langs' => {},
-          'name' => 'awesomeCalc',
-          'type' => { 'name' => 'number' },
-          'required' => true,
-          'args' => [
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => 'a',
-              'type' => { 'name' => 'number' },
-              'required' => true,
-            },
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => 'options',
-              'type' => {
-                'name' => 'Object',
-                'properties' => [
-                  {
-                    'kind' => 'property',
-                    'langs' => {
-                      'only' => ['js'],
-                    },
-                    'name' => 'b',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {
-                      'only' => ['python'],
-                    },
-                    'name' => 'bOnlyForPython',
-                    'type' => { 'name' => 'number' },
-                    'required' => true,
-                  },
-                  {
-                    'kind' => 'property',
-                    'langs' => {},
-                    'name' => 'c',
-                    'type' => { 'name' => 'number' },
-                    'required' => false,
-                  },
-                ],
-              },
-              'required' => false,
-            },
-          ],
-        }
+        api_json_hogehoge['members'] << json_method('awesomeCalc', [
+          required_arg('a', json_type('number')),
+          optional_kwarg('options', [
+            optional_arg('b', json_type('number'), langs: json_langs(only: %w(js java))),
+            optional_arg('bOnlyForPython', json_type('number'), langs: json_langs(only: 'python')),
+            optional_arg('c', json_type('number')),
+          ])
+        ])
       }
       let(:klass) do
         Class.new do
@@ -339,7 +285,7 @@ RSpec.describe 'ImplementedClassWithDoc' do
       end
 
       it 'should generate a method with argument and block' do
-        is_expected.to include("def awesome_calc(a, b: nil, c: nil, &block)\n")
+        is_expected.to include("def awesome_calc(a, bOnlyForPython: nil, c: nil, &block)\n")
       end
     end
   end
@@ -408,87 +354,27 @@ RSpec.describe 'ImplementedClassWithDoc' do
 
   describe 'alias for setter' do
     def result_arg(name)
-      {
-        "kind" => "property",
-        "langs" => {},
-        "name" => name,
-        "type" => {
-          "name" => "Object",
-          "properties" => [
-            {
-              "kind" => "property",
-              "langs" => {},
-              "name" => "x",
-              "type" => {
-                "name" => "int",
-                "expression" => "[int]"
-              },
-              "required" => true,
-            },
-            {
-              "kind" => "property",
-              "langs" => {},
-              "name" => "y",
-              "type" => {
-                "name" => "int",
-                "expression" => "[int]"
-              },
-              "required" => true,
-            }
-          ],
-          "expression" => "[Object]"
-        },
-        "required" => true,
-        "comment" => "",
-      }
-    end
-
-    def optional_arg(arg_name, *properties)
-      {
-        'kind' => 'property',
-        'langs' => {},
-        'name' => arg_name.to_s,
-        'type' => {
-          'name' => 'Object',
-          'properties' => properties.map do |name|
-            {
-              'kind' => 'property',
-              'langs' => {},
-              'name' => name.to_s,
-              'type' => { 'name' => 'number' },
-              'required' => false,
-            }
-          end
-        },
-        'required' => false,
-      }
+      object_arg(name, [
+        required_arg('x', json_type('int')),
+        required_arg('y', json_type('int')),
+      ], required: true)
     end
 
     before {
-      api_json_hogehoge['members'] << {
-        'kind' => 'method',
-        "langs" => {},
-        "name" => "setResult",
-        "type" => { "name" => "void" },
-        "required" => true,
-        "args" => [ result_arg('result') ],
-      }
-      api_json_hogehoge['members'] << {
-        'kind' => 'method',
-        "langs" => {},
-        "name" => "setResults",
-        "type" => { "name" => "void" },
-        "required" => true,
-        "args" => [ result_arg('result1'), result_arg('result2') ],
-      }
-      api_json_hogehoge['members'] << {
-        'kind' => 'method',
-        "langs" => {},
-        "name" => "setResultWithOpt",
-        "type" => { "name" => "void" },
-        "required" => true,
-        "args" => [ result_arg('result'), optional_arg('options', :timeout, :threshold) ],
-      }
+      api_json_hogehoge['members'] << json_method('setResult', [
+        result_arg('result'),
+      ], type: json_type('void'))
+      api_json_hogehoge['members'] << json_method('setResults', [
+        result_arg('result1'),
+        result_arg('result2'),
+      ], type: json_type('void'))
+      api_json_hogehoge['members'] << json_method('setResultWithOpt', [
+        result_arg('result'),
+        optional_kwarg('options', [
+          optional_arg('timeout', json_type('number')),
+          optional_arg('threshold', json_type('number')),
+        ]),
+      ], type: json_type('void'))
     }
     let(:klass) do
       Class.new do

--- a/spec/integration/page/basic_spec.rb
+++ b/spec/integration/page/basic_spec.rb
@@ -173,8 +173,8 @@ RSpec.describe Playwright::Page do
   it 'page.frame should respect name' do
     with_page do |page|
       page.content = '<iframe name=target></iframe>'
-      expect(page.frame({ name: 'bogus' })).to be_nil
-      frame = page.frame({ name: 'target' })
+      expect(page.frame(name: 'bogus')).to be_nil
+      frame = page.frame(name: 'target')
       expect(frame).to be_a(::Playwright::Frame)
       expect(frame).to eq(page.main_frame.child_frames.first)
     end
@@ -183,8 +183,8 @@ RSpec.describe Playwright::Page do
   it 'page.frame should respect url', sinatra: true do
     with_page do |page|
       page.content = "<iframe src=\"#{server_empty_page}\"></iframe>"
-      expect(page.frame({ url: /bogus/ })).to be_nil
-      frame = page.frame({ url: /empty/ })
+      expect(page.frame(url: /bogus/)).to be_nil
+      frame = page.frame(url: /empty/)
       expect(frame).to be_a(::Playwright::Frame)
       expect(frame.url).to eq(server_empty_page)
     end
@@ -249,7 +249,7 @@ RSpec.describe Playwright::Page do
       page.content = <<~HTML
       <iframe name=inner src="#{server_prefix}/input/textarea.html"></iframe>
       HTML
-      frame = page.frame('inner')
+      frame = page.frame(name: 'inner')
       frame.press('textarea', 'a')
       expect(frame.evaluate("() => document.querySelector('textarea').value")).to eq('a')
     end

--- a/spec/integration/page/set_input_files_spec.rb
+++ b/spec/integration/page/set_input_files_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe 'Page#set_input_files' do
     with_page do |page|
       expect {
         Timeout.timeout(2) do
-          page.expect_event(Playwright::Events::Page::FileChooser, optionsOrPredicate: { timeout: 10 })
+          page.expect_event(Playwright::Events::Page::FileChooser, timeout: 10)
         end
       }.to raise_error(Playwright::TimeoutError)
     end
@@ -174,7 +174,7 @@ RSpec.describe 'Page#set_input_files' do
       page.default_timeout = 0
       expect {
         Timeout.timeout(2) do
-          page.expect_event(Playwright::Events::Page::FileChooser, optionsOrPredicate: { timeout: 10 })
+          page.expect_event(Playwright::Events::Page::FileChooser, timeout: 10)
         end
       }.to raise_error(Playwright::TimeoutError)
     end
@@ -191,7 +191,7 @@ RSpec.describe 'Page#set_input_files' do
 
     with_page do |page|
       chooser = Timeout.timeout(2) do
-        page.expect_event(Playwright::Events::Page::FileChooser, optionsOrPredicate: { timeout: 0 }) do
+        page.expect_event(Playwright::Events::Page::FileChooser, timeout: 0) do
           page.evaluate(js)
         end
       end


### PR DESCRIPTION
Some method definition was strange such as:

```
page.expect_event(Playwright::Events::Page::FileChooser, optionsOrPredicate: { timeout: 10 })
```

It would be better to describe them with simple optional parameters like Python

```
page.expect_event(Playwright::Events::Page::FileChooser, timeout: 10)
```