### PR TITLE
Implement expext_xxx APIs fpr Playwright::Page

### DIFF
--- a/docs/api_coverage.md
+++ b/docs/api_coverage.md
@@ -285,11 +285,11 @@
 * wait_for_selector
 * ~~wait_for_timeout~~
 * ~~workers~~
-* ~~expect_download~~
-* ~~expect_popup~~
+* expect_download
+* expect_popup
 * ~~expect_worker~~
-* ~~expect_console_message~~
-* ~~expect_file_chooser~~
+* expect_console_message
+* expect_file_chooser
 * ~~wait_for_event~~
 * accessibility
 * keyboard

--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -634,12 +634,28 @@ module Playwright
       wait_helper.promise.value!
     end
 
+    def expect_console_message(predicate: nil, timeout: nil, &block)
+      expect_event(Events::Page::Console, predicate: predicate, timeout: timeout, &block)
+    end
+
+    def expect_download(predicate: nil, timeout: nil, &block)
+      expect_event(Events::Page::Download, predicate: predicate, timeout: timeout, &block)
+    end
+
+    def expect_file_chooser(predicate: nil, timeout: nil, &block)
+      expect_event(Events::Page::FileChooser, predicate: predicate, timeout: timeout, &block)
+    end
+
     def expect_navigation(timeout: nil, url: nil, waitUntil: nil, &block)
       @main_frame.expect_navigation(
         timeout: timeout,
         url: url,
         waitUntil: waitUntil,
         &block)
+    end
+
+    def expect_popup(predicate: nil, timeout: nil, &block)
+      expect_event(Events::Page::Popup, predicate: predicate, timeout: timeout, &block)
     end
 
     def expect_request(urlOrPredicate, timeout: nil)

--- a/spec/integration/download_spec.rb
+++ b/spec/integration/download_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe 'download', sinatra: true do
   it 'should report downloads with acceptDownloads: false' do
     with_page do |page|
       page.content = "<a href=\"#{server_prefix}#{download_with_filename_endpoint}\">download</a>"
-      download = page.expect_event('download') do
+      download = page.expect_download do
         page.click('a')
       end
 
@@ -39,7 +39,7 @@ RSpec.describe 'download', sinatra: true do
   it 'should report downloads with acceptDownloads: true' do
     with_page(acceptDownloads: true) do |page|
       page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
-      download = page.expect_event('download') do
+      download = page.expect_download do
         page.click('a')
       end
 
@@ -50,7 +50,7 @@ RSpec.describe 'download', sinatra: true do
   it 'should save to user-specified path' do
     with_page(acceptDownloads: true) do |page|
       page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
-      download = page.expect_event('download') do
+      download = page.expect_download do
         page.click('a')
       end
       Dir.mktmpdir do |dir|
@@ -64,7 +64,7 @@ RSpec.describe 'download', sinatra: true do
   it 'should save to user-specified path without updating original path' do
     with_page(acceptDownloads: true) do |page|
       page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
-      download = page.expect_event('download') do
+      download = page.expect_download do
         page.click('a')
       end
       Dir.mktmpdir do |dir|
@@ -281,7 +281,7 @@ RSpec.describe 'download', sinatra: true do
   it 'should delete file' do
     with_page(acceptDownloads: true) do |page|
       page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
-      download = page.expect_event('download') do
+      download = page.expect_download do
         page.click('a')
       end
       path = download.path

--- a/spec/integration/page/set_input_files_spec.rb
+++ b/spec/integration/page/set_input_files_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe 'Page#set_input_files' do
   it 'should work when file input is attached to DOM' do
     with_page do |page|
       page.content = '<input type=file>'
-      chooser = page.expect_event(Playwright::Events::Page::FileChooser) do
+      chooser = page.expect_file_chooser do
         page.click('input')
       end
       expect(chooser).to be_a(Playwright::FileChooser)
@@ -88,7 +88,7 @@ RSpec.describe 'Page#set_input_files' do
     JAVASCRIPT
 
     with_page do |page|
-      chooser = page.expect_event(Playwright::Events::Page::FileChooser) do
+      chooser = page.expect_file_chooser do
         page.evaluate(js)
       end
       expect(chooser).to be_a(Playwright::FileChooser)
@@ -152,7 +152,7 @@ RSpec.describe 'Page#set_input_files' do
     with_page do |page|
       expect {
         Timeout.timeout(2) do
-          page.expect_event(Playwright::Events::Page::FileChooser, timeout: 10)
+          page.expect_file_chooser(timeout: 10)
         end
       }.to raise_error(Playwright::TimeoutError)
     end
@@ -163,7 +163,7 @@ RSpec.describe 'Page#set_input_files' do
       page.default_timeout = 10
       expect {
         Timeout.timeout(2) do
-          page.expect_event(Playwright::Events::Page::FileChooser)
+          page.expect_file_chooser
         end
       }.to raise_error(Playwright::TimeoutError)
     end
@@ -174,7 +174,7 @@ RSpec.describe 'Page#set_input_files' do
       page.default_timeout = 0
       expect {
         Timeout.timeout(2) do
-          page.expect_event(Playwright::Events::Page::FileChooser, timeout: 10)
+          page.expect_file_chooser(timeout: 10)
         end
       }.to raise_error(Playwright::TimeoutError)
     end
@@ -191,7 +191,7 @@ RSpec.describe 'Page#set_input_files' do
 
     with_page do |page|
       chooser = Timeout.timeout(2) do
-        page.expect_event(Playwright::Events::Page::FileChooser, timeout: 0) do
+        page.expect_file_chooser(timeout: 0) do
           page.evaluate(js)
         end
       end
@@ -325,7 +325,7 @@ RSpec.describe 'Page#set_input_files' do
   it 'should work for single file pick' do
     with_page do |page|
       page.content = '<input type=file>'
-      chooser = page.expect_event(Playwright::Events::Page::FileChooser) do
+      chooser = page.expect_file_chooser do
         page.click('input')
       end
       expect(chooser).not_to be_multiple
@@ -335,7 +335,7 @@ RSpec.describe 'Page#set_input_files' do
   it 'should work for "multiple"' do
     with_page do |page|
       page.content = '<input multiple type=file>'
-      chooser = page.expect_event(Playwright::Events::Page::FileChooser) do
+      chooser = page.expect_file_chooser do
         page.click('input')
       end
       expect(chooser).to be_multiple


### PR DESCRIPTION
playwright-python introduces some alias methods for `expect_event('download')` `expect_event('file_chooser')` and so on.
Let's use them also in playwright-ruby-client