### PR TITLE
Make playwright-ruby-client Windows-compatible

### DIFF
--- a/.github/workflows/windows_check.yml
+++ b/.github/workflows/windows_check.yml
@@ -1,0 +1,26 @@
+name: Windows check
+on: [pull_request]
+jobs:
+  windows_chrome_rspec:
+    name: RSpec on Windows / Chrome
+    runs-on: windows-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.0
+          bundler-cache: true
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      - name: Download and Install playwright driver
+        run: |
+          wget -O driver.zip https://playwright.azureedge.net/builds/driver/next/playwright-$(cat development/CLI_VERSION)-win32.zip
+          unzip driver.zip && rm driver.zip
+          .\playwright.cmd install
+      - run: bundle exec ruby development/generate_api.rb
+      - name: Check example
+        run: bundle exec rspec spec/integration/example_spec.rb
+        env:
+          PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./playwright.cmd

--- a/spec/integration/example_spec.rb
+++ b/spec/integration/example_spec.rb
@@ -7,10 +7,13 @@ RSpec.describe 'example', skip: ENV['CI'] do
   it 'should take a screenshot' do
     with_page do |page|
       page.goto('https://github.com/YusukeIwaki')
-      Dir.mktmpdir do |tmp|
-        path = File.join(tmp, 'YusukeIwaki.png')
+      tmpdir = Dir.mktmpdir
+      begin
+        path = File.join(tmpdir, 'YusukeIwaki.png')
         page.screenshot(path: path)
-        expect(File.open(path).read.size).to be > 1000
+        expect(File.open(path, 'rb').read.size).to be > 1000
+      ensure
+        FileUtils.remove_entry(tmpdir, true)
       end
     end
   end

--- a/spec/integration/example_spec.rb
+++ b/spec/integration/example_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'tmpdir'
 
-RSpec.describe 'example', skip: ENV['CI'] do
+RSpec.describe 'example' do
   it 'should take a screenshot' do
     with_page do |page|
       page.goto('https://github.com/YusukeIwaki')
@@ -18,7 +18,7 @@ RSpec.describe 'example', skip: ENV['CI'] do
     end
   end
 
-  it 'should input text and grab DOM elements' do
+  it 'should input text and grab DOM elements', skip: ENV['CI'] do
     with_page do |page|
       page = browser.new_page
       page.viewport_size = { width: 1280, height: 800 }


### PR DESCRIPTION
playwright-ruby-client is already windows-compatible.
However some specs are incompatible...