### PR TITLE
Add spec for playwright.devices

### DIFF
--- a/lib/playwright/channel_owners/playwright.rb
+++ b/lib/playwright/channel_owners/playwright.rb
@@ -24,38 +24,31 @@ module Playwright
       @selectors ||= ::Playwright::ChannelOwners::Selectors.from(@initializer['selectors'])
     end
 
-    class DeviceDescriptor
-      class Viewport
-        def initialize(hash)
-          @width = hash['width']
-          @heirhgt = hash['height']
-        end
-        attr_reader :width, :height
-      end
-
-      def initialize(hash)
-        @user_agent = hash["userAgent"]
-        @viewport = Viewport.new(hash["viewport"])
-        @device_scale_factor = hash["deviceScaleFactor"]
-        @is_mobile = hash["isMobile"]
-        @has_touch = hash["hasTouch"]
-      end
-
-      attr_reader :user_agent, :viewport, :device_scale_factor
-
-      def mobile?
-        @is_mobile
-      end
-
-      def has_touch?
-        @has_touch
-      end
-    end
-
     def devices
       @devices ||= @initializer['deviceDescriptors'].map do |item|
-        [item['name'], DeviceDescriptor.new(item['descriptor'])]
+        [item['name'], parse_device_descriptor(item['descriptor'])]
       end.to_h
+    end
+
+    private def parse_device_descriptor(descriptor)
+      # This return value can be passed into Browser#new_context as it is.
+      # ex:
+      # ```
+      #   iPhone = playwright.devices['iPhone 6']
+      #   context = browser.new_context(**iPhone)
+      #   page = context.new_page
+      #
+      # ```
+      {
+        userAgent: descriptor['userAgent'],
+        viewport: {
+          width: descriptor['viewport']['width'],
+          height: descriptor['viewport']['height'],
+        },
+        deviceScaleFactor: descriptor['deviceScaleFactor'],
+        isMobile: descriptor['isMobile'],
+        hasTouch: descriptor['hasTouch'],
+      }
     end
   end
 end

--- a/spec/integration/browser_context/device_spec.rb
+++ b/spec/integration/browser_context/device_spec.rb
@@ -1,0 +1,79 @@
+require 'spec_helper'
+
+RSpec.describe 'device' do
+  it 'should work', sinatra: true do
+    iPhone = playwright.devices['iPhone 6'];
+    with_context(**iPhone) do |context|
+      page = context.new_page
+      page.goto("#{server_prefix}/mobile.html")
+      expect(page.evaluate('() => window.innerWidth')).to eq(375)
+      expect(page.evaluate('() => navigator.userAgent')).to include('iPhone');
+    end
+  end
+
+  it 'should support clicking', sinatra: true do
+    iPhone = playwright.devices['iPhone 6'];
+    with_context(**iPhone) do |context|
+      page = context.new_page
+      page.goto("#{server_prefix}/input/button.html")
+      button = page.query_selector('button')
+      page.evaluate("button => button.style.marginTop = '200px'", arg: button)
+      button.click
+      expect(page.evaluate('result')).to eq('Clicked')
+    end
+  end
+
+  it 'should scroll to click', sinatra: true do
+    with_context(viewport: { width: 400, height: 400 }, deviceScaleFactor: 1, isMobile: true) do |context|
+      page = context.new_page
+      page.goto("#{server_prefix}/input/scrollable.html")
+      button = page.query_selector('#button-91')
+      button.click
+      expect(button.text_content).to eq('clicked')
+    end
+  end
+
+  it 'should scroll twice when emulated' do
+    iPhone = playwright.devices['iPhone 6']
+    with_context(**iPhone) do |context|
+      page = context.new_page
+      page.content = [
+        '<meta name="viewport" content="width=device-width, user-scalable=no" />',
+        "Lorem ipsum dolor sit amet consectetur adipiscing elit proin, integer curabitur imperdiet rhoncus cursus tincidunt bibendum, consequat sed magnis laoreet luctus mollis tellus. Nisl parturient mus accumsan feugiat sem laoreet magnis nisi, aptent per sollicitudin gravida orci ac blandit, viverra eros praesent auctor vivamus semper bibendum. Consequat sed habitasse luctus dictumst gravida platea semper phasellus, nascetur ridiculus purus est varius quisque et scelerisque, id vehicula eleifend montes sollicitudin dis velit. Pellentesque ridiculus per natoque et eleifend taciti nunc, laoreet auctor at condimentum imperdiet ante, conubia mi cubilia scelerisque sociosqu sem.</p> <p>Curabitur magna per felis primis mauris non dapibus luctus ultricies eros, quis et egestas condimentum lobortis eget semper montes litora purus, ridiculus elementum sollicitudin imperdiet dictum lacinia parturient cras eu. Risus cum varius rhoncus eros torquent pretium taciti id erat dis egestas, nibh tristique montes convallis metus lacus phasellus blandit ut auctor bibendum semper, facilisis mi integer eget ultrices lobortis odio viverra duis dui. Risus ullamcorper lacinia in venenatis sodales fusce tortor potenti volutpat quis, dictum vulputate suspendisse velit mollis torquent sociis aptent morbi, senectus nascetur justo maecenas conubia magnis viverra gravida fames. Phasellus sed nec gravida nibh class augue lectus, blandit quis turpis orci diam nam pellentesque, ultricies metus imperdiet hendrerit lacinia lacus.</p> <p>Inceptos facilisi montes cum hendrerit, pulvinar ut tellus eget velit, arcu nulla aenean. Phasellus augue urna nostra molestie interdum vehicula, posuere fames cum euismod massa curabitur donec, inceptos cubilia tellus facilisis fermentum. Lacus laoreet facilisis ultrices cursus quisque at ad porta vestibulum massa inceptos, curae class aliquet maecenas cum ullamcorper pulvinar erat mus vitae. Cum in aenean convallis dis quam tincidunt justo sed quisque, imperdiet faucibus hendrerit felis commodo scelerisque magnis vehicula etiam leo, eros varius platea lobortis maecenas condimentum nisi phasellus. Turpis vulputate mus himenaeos sociosqu facilisis dignissim leo quam, ultricies habitasse commodo molestie est tortor vitae et, porttitor risus erat cursus phasellus facilisi litora.</p> <p>Nostra habitasse egestas magnis velit pellentesque parturient cum lectus viverra, vestibulum sociosqu nunc vel urna consequat lacinia phasellus at sapien, aenean pretium dictum sed montes interdum imperdiet iaculis. Leo hac eros arcu senectus maecenas, tortor pulvinar venenatis lacinia volutpat, mattis platea ut facilisi. Aenean condimentum at et donec sociosqu fermentum luctus potenti semper vulputate, sapien justo non est auctor gravida ultricies fames per commodo, sed habitasse facilisi nulla quisque hendrerit aliquet viverra bibendum.</p> <p>Interdum nisl quam etiam montes porttitor laoreet nullam senectus velit, mauris proin tellus imperdiet litora venenatis fames massa quis, sollicitudin justo vivamus curae in sociis suscipit facilisi. Platea inceptos lacus elementum pellentesque quam euismod dictumst sociis tincidunt vulputate porttitor eros, turpis netus ut ad tempor sapien aliquet sodales molestie consequat nostra. Cum augue in quisque primis ut nunc sodales, sem orci tempus posuere cubilia suspendisse lacinia ligula, magna sed ridiculus at maecenas habitant.</p> <p>Natoque magna ac feugiat tellus bibendum diam, metus lobortis nisl ornare varius praesent, dictumst gravida lacus parturient semper. Pellentesque faucibus congue fusce posuere placerat dictum vitae, dui vestibulum eu sociis tempus aliquam ultricies malesuada, potenti laoreet lacus sem gravida nisi. Nostra platea sagittis hendrerit congue conubia senectus bibendum quis sapien pharetra, scelerisque nam imperdiet fermentum feugiat suspendisse viverra luctus at, semper ac consequat vitae mi gravida parturient mollis nascetur. Vel taciti justo consequat primis et blandit convallis sed, felis purus fusce a venenatis etiam aenean scelerisque, fringilla volutpat sagittis egestas rutrum id dis.</p> <p>Feugiat fermentum tortor ante ac iaculis sollicitudin ut interdum, cras orci ullamcorper potenti tristique vehicula. Molestie tortor ullamcorper rutrum turpis malesuada phasellus sem ultricies praesent mattis lobortis porta, senectus venenatis diam nostra laoreet volutpat per aptent justo elementum cum. Urna cursus vel felis cras eleifend arcu enim magnis, duis rutrum nibh nascetur cubilia interdum ultrices curae, id lacus aliquam dictumst diam fringilla lacinia.</p> <p>Luctus diam morbi eget tellus libero taciti faucibus inceptos, natoque facilisis lectus maecenas risus dapibus suscipit nibh, vel curae conubia orci imperdiet metus fusce. Condimentum massa donec luctus pharetra cum, in viverra placerat nisl litora facilisis, neque nascetur sociis dictumst. Suscipit accumsan eget rhoncus pharetra justo malesuada aliquet, suspendisse metus eleifend tincidunt varius ridiculus, convallis primis vitae curabitur quis mus.</p> <p>Gravida donec lacus molestie tortor aenean ultricies blandit per tempor, nostra penatibus orci vestibulum semper lectus vel a, montes potenti cum dapibus natoque eu volutpat nulla. Himenaeos purus nam malesuada habitasse nisl pharetra laoreet feugiat mi non, ultrices ultricies a cras ante eu venenatis ligula. Suscipit ut mus habitasse at aliquet sodales commodo justo, feugiat platea sagittis phasellus eleifend pellentesque interdum iaculis, integer cubilia montes metus hendrerit tincidunt purus.</p> <p>Vel posuere tellus dapibus eget duis cubilia, nec class vehicula libero gravida ligula, tempus urna taciti donec congue. Facilisis ridiculus congue cum dui per augue natoque, molestie hac etiam pellentesque dignissim urna class, feugiat aenean massa himenaeos penatibus ut eu, convallis purus et fusce tempus mattis. At mattis suscipit porta nostra nec facilisis sodales turpis, integer et lectus conubia justo nam congue taciti odio, fermentum semper cubilia fusce nunc purus velit.",
+        '<button>hi</button>',
+      ].join("")
+
+      page.evaluate('() => window.scroll(0, 100)')
+      expect(page.evaluate('() => window.scrollY')).to eq(100)
+
+      page.evaluate('() => window.scroll(0, 200)')
+      expect(page.evaluate('() => window.scrollY')).to eq(200)
+    end
+  end
+
+  it 'should reset scroll top after a navigation', sinatra: true do
+    iPhone = playwright.devices['iPhone 6']
+    with_context(**iPhone) do |context|
+      page = context.new_page
+      page.goto("#{server_prefix}/input/scrollable.html")
+
+      page.evaluate('() => window.scroll(0, 100)')
+      page.goto("#{server_prefix}/input/scrollable2.html")
+      expect(page.evaluate('() => window.scrollY')).to eq(0)
+    end
+  end
+
+  it 'should scroll to a precise position with mobile scale', sinatra: true do
+    pending if webkit?
+
+    iPhone = playwright.devices['iPhone 6']
+    with_context(**iPhone) do |context|
+      page = context.new_page
+      page.goto("#{server_prefix}/input/scrollable.html")
+      expect(page.evaluate('() => document.body.scrollHeight')).to be > 100
+
+      page.evaluate('() => window.scroll(0, 100)')
+      expect(page.evaluate('() => window.scrollY')).to eq(100)
+    end
+  end
+end


### PR DESCRIPTION
Allow device emulation like playwright-python.

```ruby
require 'playwright'

Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
  iPhone = playwright.devices['iPhone 6']
  playwright.chromium.launch(headless: false) do |browser|
    page = browser.new_page(**iPhone)

    page.goto("https://ifconfig.me/ua")
    puts page.evaluate('() => document.body.textContent') # => Mozilla/5.0 (iPhone; CPU iPhone OS 11_0 like Mac OS X) AppleWebKit/604.1.38 (KHTML, like Gecko) Version/11.0 Mobile/15A372 Safari/604.1
  end
end

```