### PR TITLE
Allow using npx for playwright_cli_executable_path

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,15 +71,16 @@ jobs:
             echo . $(rvm 2.7.2 do rvm env --path) >> $BASH_ENV
             gem install bundler:2.2.3 && bundle install
       - run:
-          name: setup playwright via npx
+          name: setup playwright via npm install
           command: |
-            npm_config_unsafe_perm=true npx playwright install
+            npm install playwright
+            ./node_modules/.bin/playwright install
       - run:
           command: bundle exec ruby development/generate_api.rb
       - run:
           name: RSpec
           command: |
-            DEBUG=1 npm_config_unsafe_perm=true PLAYWRIGHT_CLI_EXECUTABLE_PATH="npx playwright" \
+            DEBUG=1 PLAYWRIGHT_CLI_EXECUTABLE_PATH=./node_modules/.bin/playwright \
             xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration \
             --format RspecJunitFormatter \
             --out test_results/rspec.xml \
@@ -113,15 +114,16 @@ jobs:
             echo . $(rvm 2.7.2 do rvm env --path) >> $BASH_ENV
             gem install bundler:2.2.3 && bundle install
       - run:
-          name: setup playwright via npx
+          name: setup playwright via npm install
           command: |
-            npm_config_unsafe_perm=true npx playwright install
+            npm install playwright
+            ./node_modules/.bin/playwright install
       - run:
           command: bundle exec ruby development/generate_api.rb
       - run:
           name: RSpec
           command: |
-            BROWSER=webkit DEBUG=1 npm_config_unsafe_perm=true PLAYWRIGHT_CLI_EXECUTABLE_PATH="npx playwright" \
+            BROWSER=webkit DEBUG=1 PLAYWRIGHT_CLI_EXECUTABLE_PATH=./node_modules/.bin/playwright \
             xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration \
             --format RspecJunitFormatter \
             --out test_results/rspec.xml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,16 +71,15 @@ jobs:
             echo . $(rvm 2.7.2 do rvm env --path) >> $BASH_ENV
             gem install bundler:2.2.3 && bundle install
       - run:
-          name: setup playwright via npm install
+          name: setup playwright via npx
           command: |
-            npm install playwright
-            ./node_modules/.bin/playwright install
+            npm_config_unsafe_perm=true npx playwright install
       - run:
           command: bundle exec ruby development/generate_api.rb
       - run:
           name: RSpec
           command: |
-            DEBUG=1 PLAYWRIGHT_CLI_EXECUTABLE_PATH=./node_modules/.bin/playwright \
+            DEBUG=1 npm_config_unsafe_perm=true PLAYWRIGHT_CLI_EXECUTABLE_PATH="npx playwright" \
             xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration \
             --format RspecJunitFormatter \
             --out test_results/rspec.xml \
@@ -114,16 +113,15 @@ jobs:
             echo . $(rvm 2.7.2 do rvm env --path) >> $BASH_ENV
             gem install bundler:2.2.3 && bundle install
       - run:
-          name: setup playwright via npm install
+          name: setup playwright via npx
           command: |
-            npm install playwright
-            ./node_modules/.bin/playwright install
+            npm_config_unsafe_perm=true npx playwright install
       - run:
           command: bundle exec ruby development/generate_api.rb
       - run:
           name: RSpec
           command: |
-            BROWSER=webkit DEBUG=1 PLAYWRIGHT_CLI_EXECUTABLE_PATH=./node_modules/.bin/playwright \
+            BROWSER=webkit DEBUG=1 npm_config_unsafe_perm=true PLAYWRIGHT_CLI_EXECUTABLE_PATH="npx playwright" \
             xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration \
             --format RspecJunitFormatter \
             --out test_results/rspec.xml \

--- a/.github/workflows/windows_check.yml
+++ b/.github/workflows/windows_check.yml
@@ -14,13 +14,11 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
-      - name: Download and Install playwright driver
+      - name: Install playwright driver via npx
         run: |
-          wget -O driver.zip https://playwright.azureedge.net/builds/driver/next/playwright-$(cat development/CLI_VERSION)-win32.zip
-          unzip driver.zip && rm driver.zip
-          .\playwright.cmd install
+          npx playwright install
       - run: bundle exec ruby development/generate_api.rb
       - name: Check example
         run: bundle exec rspec spec/integration/example_spec.rb
         env:
-          PLAYWRIGHT_CLI_EXECUTABLE_PATH: ./playwright.cmd
+          PLAYWRIGHT_CLI_EXECUTABLE_PATH: npx playwright

--- a/README.md
+++ b/README.md
@@ -9,22 +9,34 @@ Note: Currently, this Gem is just a PoC (Proof of Concept). If you want to devel
 At this point, playwright-ruby-client doesn't include the downloader of playwright driver, so **we have to install [playwright](https://github.com/microsoft/playwright) in advance**.
 
 ```sh
+npx playwright install
+```
+
+and then, set `playwright_cli_executable_path: "npx playwright"` at `Playwright.create`.
+
+**Prefer npm install instead of npx?**
+
+Actually `npx playwright` is a bit slow. We can also use `npm install` to setup.
+
+Instead of `npx playwright install`:
+
+```
 npm install playwright
 ./node_modules/.bin/playwright install
 ```
 
-and then, set `playwright_cli_executable_path: ./node_modules/.bin/playwright` at `Playwright.create`.
+And set `playwright_cli_executable_path: './node_modules/.bin/playwright'`
 
 **Prefer playwrighting without Node.js?**
 
-Instead of npm install, you can also directly download playwright driver from playwright.azureedge.net/builds/. The URL can be easily detected from [here](https://github.com/microsoft/playwright-python/blob/79f6ce0a6a69c480573372706df84af5ef99c4a4/setup.py#L56-L61)
+Instead of npm, you can also directly download playwright driver from playwright.azureedge.net/builds/. The URL can be easily detected from [here](https://github.com/microsoft/playwright-python/blob/79f6ce0a6a69c480573372706df84af5ef99c4a4/setup.py#L56-L61)
 
 ### Capture a site
 
 ```ruby
 require 'playwright'
 
-Playwright.create(playwright_cli_executable_path: '/path/to/playwright') do |playwright|
+Playwright.create(playwright_cli_executable_path: 'npx playwright') do |playwright|
   playwright.chromium.launch(headless: false) do |browser|
     page = browser.new_page
     page.goto('https://github.com/YusukeIwaki')
@@ -40,7 +52,7 @@ end
 ```ruby
 require 'playwright'
 
-Playwright.create(playwright_cli_executable_path: './node_modules/.bin/playwright') do |playwright|
+Playwright.create(playwright_cli_executable_path: 'npx playwright') do |playwright|
   playwright.chromium.launch(headless: false) do |browser|
     page = browser.new_page
     page.goto('https://github.com/')
@@ -82,7 +94,7 @@ $ bundle exec ruby main.rb
 ```ruby
 require 'playwright'
 
-Playwright.create(playwright_cli_executable_path: './node_modules/.bin/playwright') do |playwright|
+Playwright.create(playwright_cli_executable_path: 'npx playwright') do |playwright|
   devices = playwright.android.devices
   unless devices.empty?
     device = devices.last

--- a/lib/playwright/transport.rb
+++ b/lib/playwright/transport.rb
@@ -43,7 +43,7 @@ module Playwright
     #
     # @note This method blocks until playwright-cli exited. Consider using Thread or Future.
     def run
-      @stdin, @stdout, @stderr, @thread = Open3.popen3(@driver_executable_path, 'run-driver')
+      @stdin, @stdout, @stderr, @thread = Open3.popen3("#{@driver_executable_path} run-driver")
 
       Thread.new { handle_stdout }
       Thread.new { handle_stderr }


### PR DESCRIPTION
In browser automation, most users prefer `npx playwright` instead of installing playwright locally.
So enable us to specify `playwright_cli_executable_path: 'npx playwright'` :)