### PR TITLE
Introduce socketry/async instead of concurrent-ruby

### DIFF
--- a/development/generate_api/views/documented_method_args.rb
+++ b/development/generate_api/views/documented_method_args.rb
@@ -1,5 +1,3 @@
-require 'concurrent'
-
 class DocumentedMethodArgs
   class RequiredArg
     def initialize(doc)

--- a/development/generate_api/views/undocumented_method_args.rb
+++ b/development/generate_api/views/undocumented_method_args.rb
@@ -1,5 +1,3 @@
-require 'concurrent'
-
 class UndocumentedMethodArgs
   class RequiredArg
     def initialize(name)

--- a/lib/playwright/async_evaluation.rb
+++ b/lib/playwright/async_evaluation.rb
@@ -1,0 +1,28 @@
+require 'async/condition'
+
+module Playwright
+  # Async { } wrapper, providing Concurrent::Promises::Future-like APIs
+  class AsyncEvaluation
+    def initialize(&block)
+      raise ArgumentError.new('block must be given') unless block
+
+      @task = Async(&block)
+    end
+
+    def resolved?
+      %i(complete stopped failed).include?(@task.status)
+    end
+
+    def fulfilled?
+      @task.status == :complete
+    end
+
+    def rejected?
+      %i(stopped failed).include?(@task.status)
+    end
+
+    def value!
+      @task.result
+    end
+  end
+end

--- a/lib/playwright/async_value.rb
+++ b/lib/playwright/async_value.rb
@@ -1,0 +1,67 @@
+require 'async/condition'
+
+module Playwright
+  # Async::Condition wrapper, providing Concurrent::Promises::Future-like APIs
+  class AsyncValue
+    def initialize
+      @fulfilled = false
+      @resolved = false
+      @value = nil
+    end
+
+    def fulfill(value = nil)
+      raise ArgumentError.new('already resolved') if @resolved
+
+      @fulfilled = true
+      @resolved = true
+      @value = value
+      @notification&.signal(@value)
+
+      nil
+    end
+
+    class Rejection < StandardError ; end
+
+    def reject(error)
+      raise ArgumentError.new('already resolved') if @resolved
+
+      @resolved = true
+      if error.is_a?(StandardError)
+        @value = error
+      else
+        @value = Rejection.new(error)
+      end
+      @notification&.signal(@value)
+
+      nil
+    end
+
+    def resolved?
+      @resolved
+    end
+
+    def fulfilled?
+      @resolved && @fulfilled
+    end
+
+    def rejected?
+      @resolved && !@fulfilled
+    end
+
+    def value!
+      result = wait_for_value
+      if result.is_a?(StandardError)
+        raise result
+      else
+        result
+      end
+    end
+
+    private def wait_for_value
+      return @value if @resolved
+
+      @notification = Async::Condition.new
+      @notification.wait
+    end
+  end
+end

--- a/lib/playwright/channel.rb
+++ b/lib/playwright/channel.rb
@@ -16,20 +16,22 @@ module Playwright
     # @param method [String]
     # @param params [Hash]
     def send_message_to_server(method, params = {})
-      async_send_message_to_server(method, params).value!
+      result = @connection.send_message_to_server(@guid, method, params)
+      if result.is_a?(Hash)
+        _type, channel_owner = result.first
+        channel_owner
+      else
+        nil
+      end
     end
 
     # @param method [String]
     # @param params [Hash]
+    # @returns nil
     def async_send_message_to_server(method, params = {})
-      @connection.async_send_message_to_server(@guid, method, params).then do |result|
-        if result.is_a?(Hash)
-          _type, channel_owner = result.first
-          channel_owner
-        else
-          nil
-        end
-      end
+      @connection.async_send_message_to_server(@guid, method, params)
+
+      nil
     end
   end
 end

--- a/lib/playwright/connection.rb
+++ b/lib/playwright/connection.rb
@@ -25,30 +25,26 @@ module Playwright
       @root_object = RootChannelOwner.new(self)
     end
 
-    def run
-      @transport.run
+    def async_run
+      @transport.async_run
     end
 
     def stop
       @transport.stop
     end
 
-    def async_wait_for_object_with_known_name(guid)
+    def wait_for_object_with_known_name(guid)
       if @objects[guid]
         return @objects[guid]
       end
 
-      callback = Concurrent::Promises.resolvable_future
+      callback = AsyncValue.new
       @waiting_for_object[guid] = callback
-      callback
-    end
-
-    def wait_for_object_with_known_name(guid)
-      async_wait_for_object_with_known_name.value!
+      callback.value!
     end
 
     def async_send_message_to_server(guid, method, params)
-      callback = Concurrent::Promises.resolvable_future
+      callback = AsyncValue.new
 
       with_generated_id do |id|
         # register callback promise object first.

--- a/lib/playwright/wait_helper.rb
+++ b/lib/playwright/wait_helper.rb
@@ -56,7 +56,7 @@ module Playwright
         emitter.off(event, listener)
       end
       @registered_listeners.clear
-      @timeout_task&.stop
+      Async { @timeout_task&.stop }
     end
 
     private def fulfill(*args)

--- a/lib/playwright/wait_helper.rb
+++ b/lib/playwright/wait_helper.rb
@@ -3,7 +3,7 @@ module Playwright
   # ref: https://github.com/microsoft/playwright/blob/01fb3a6045cbdb4b5bcba0809faed85bd917ab87/src/client/waiter.ts#L21
   class WaitHelper
     def initialize
-      @promise = Concurrent::Promises.resolvable_future
+      @promise = AsyncValue.new
       @registered_listeners = Set.new
     end
 
@@ -22,9 +22,11 @@ module Playwright
     def reject_on_timeout(timeout_ms, message)
       return if timeout_ms <= 0
 
-      Concurrent::Promises.schedule(timeout_ms / 1000.0) {
+      @timeout_task&.stop
+      @timeout_task = Async do |task|
+        task.sleep(timeout_ms / 1000.0)
         reject(TimeoutError.new(message: message))
-      }
+      end
 
       self
     end
@@ -54,6 +56,7 @@ module Playwright
         emitter.off(event, listener)
       end
       @registered_listeners.clear
+      @timeout_task&.stop
     end
 
     private def fulfill(*args)

--- a/playwright.gemspec
+++ b/playwright.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'concurrent-ruby'
+  spec.add_dependency 'async'
+  spec.add_dependency 'async-io'
   spec.add_dependency 'mime-types', '>= 3.0'
   spec.add_development_dependency 'bundler', '~> 2.2.3'
   spec.add_development_dependency 'dry-inflector'

--- a/spec/integration/browser_context/device_spec.rb
+++ b/spec/integration/browser_context/device_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe 'device' do
   end
 
   it 'should scroll to a precise position with mobile scale', sinatra: true do
-    pending if webkit?
+    skip if webkit?
 
     iPhone = playwright.devices['iPhone 6']
     with_context(**iPhone) do |context|

--- a/spec/integration/browser_context/route_spec.rb
+++ b/spec/integration/browser_context/route_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'BrowserContext#route', sinatra: true do
   it 'should intercept' do
     with_context do |context|
       intercepted = false
-      promise = Concurrent::Promises.resolvable_future
+      promise = Playwright::AsyncValue.new
       request_frame_url = nil
       context.route('**/empty.html', ->(route, request) {
         promise.fulfill(request)

--- a/spec/integration/element_handle/wait_for_element_state_spec.rb
+++ b/spec/integration/element_handle/wait_for_element_state_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       page.content = "<div style='display:none'>content</div>"
       div = page.query_selector('div')
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         div.wait_for_element_state('visible')
         done = true
       }
@@ -45,8 +45,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
     with_page do |page|
       page.content = "<div style='display:none'>content</div>"
       div = page.query_selector('div')
-      promise = Concurrent::Promises.future { div.wait_for_element_state('visible') }
-      sleep 0.5
+      promise = Playwright::AsyncEvaluation.new { div.wait_for_element_state('visible') }
       div.evaluate("div => div.remove()")
       expect { promise.value! }.to raise_error(/Element is not attached to the DOM/)
     end
@@ -57,7 +56,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       page.content = '<div>content</div>'
       div = page.query_selector('div')
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         div.wait_for_element_state('hidden')
         done = true
       }
@@ -82,7 +81,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       page.content = '<div>content</div>'
       div = page.query_selector('div')
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         div.wait_for_element_state('hidden')
         done = true
       }
@@ -99,7 +98,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       page.content = '<button disabled><span>Target</span></button>'
       span = page.query_selector('text=Target')
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         span.wait_for_element_state('enabled')
         done = true
       }
@@ -115,8 +114,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
     with_page do |page|
       page.content = '<button disabled>Target</button>'
       button = page.query_selector('button')
-      promise = Concurrent::Promises.future { button.wait_for_element_state('enabled') }
-      sleep 0.5
+      promise = Playwright::AsyncEvaluation.new { button.wait_for_element_state('enabled') }
       button.evaluate("button => button.remove()")
       expect { promise.value! }.to raise_error(/Element is not attached to the DOM/)
     end
@@ -127,7 +125,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       page.content = '<button><span>Target</span></button>'
       span = page.query_selector('text=Target')
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         span.wait_for_element_state('disabled')
         done = true
       }
@@ -146,7 +144,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       button.evaluate("button => { button.style.transition = 'margin 10000ms linear 0s'; button.style.marginLeft = '20000px'; }")
 
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         button.wait_for_element_state('stable')
         done = true
       }
@@ -163,7 +161,7 @@ RSpec.describe 'ElementHandle#wait_for_element_state' do
       page.content = '<input readonly>'
       input = page.query_selector('input')
       done = false
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         input.wait_for_element_state('editable')
         done = true
       }

--- a/spec/integration/page/autowaiting_basic_spec.rb
+++ b/spec/integration/page/autowaiting_basic_spec.rb
@@ -19,6 +19,10 @@ RSpec.describe 'autowaiting basic' do
     messages
   end
 
+  def await_all(futures)
+    futures.map(&:value!)
+  end
+
   it 'should await navigation when clicking anchor', sinatra: true do
     messages = init_server
 
@@ -26,17 +30,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.click('a')
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -49,17 +52,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.evaluate("() => window.anchor.click()")
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -72,17 +74,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.eval_on_selector('#anchor', "(anchor) => anchor.click()")
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -96,17 +97,16 @@ RSpec.describe 'autowaiting basic' do
       handle = page.evaluate_handle('document')
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           handle.evaluate("(doc) => doc.getElementById('anchor').click()")
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -120,17 +120,16 @@ RSpec.describe 'autowaiting basic' do
       handle = page.query_selector('body')
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           handle.eval_on_selector('#anchor', "(anchor) => anchor.click()")
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -143,17 +142,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = "<a href=\"#{server_cross_process_prefix}#{endpoint}\" >empty.html</a>"
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.click('a')
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -166,17 +164,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = "<a id=\"anchor\" href=\"#{server_cross_process_prefix}#{endpoint}\" >empty.html</a>"
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.evaluate('window.anchor.click()')
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -195,17 +192,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = html
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.click('input[type=submit]')
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -224,17 +220,16 @@ RSpec.describe 'autowaiting basic' do
       page.content = html
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.click('input[type=submit]')
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated click))
@@ -245,17 +240,16 @@ RSpec.describe 'autowaiting basic' do
 
     with_page do |page|
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.evaluate("window.location.href = \"#{server_cross_process_prefix}#{endpoint}\"")
           messages << 'evaluate'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated evaluate))
@@ -288,17 +282,16 @@ RSpec.describe 'autowaiting basic' do
       messages.clear
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.evaluate('window.location.reload()')
           messages << 'evaluate'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
 
     expect(messages).to eq(%w(route navigated evaluate))
@@ -318,17 +311,16 @@ RSpec.describe 'autowaiting basic' do
 
       frame = page.frame({name: 'target'})
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.click('a')
           messages << 'click'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           messages << 'navigated'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
       expect(frame.url).to eq("#{server_prefix}#{endpoint}")
     end
 
@@ -369,7 +361,6 @@ RSpec.describe 'autowaiting basic' do
       body("<link rel='stylesheet' href='.#{css_path}'>")
     end
     sinatra.get(css_path) do
-      sleep 0.5
       'a { font-size: 12pt }'
     end
 
@@ -377,19 +368,18 @@ RSpec.describe 'autowaiting basic' do
       page.content = "<a href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
 
       promises = [
-        Concurrent::Promises.future {
-          sleep 0.5
+        Playwright::AsyncEvaluation.new {
           page.click('a')
           page.wait_for_load_state(state: 'load')
           messages << 'clickload'
         },
-        Concurrent::Promises.future {
+        Playwright::AsyncEvaluation.new {
           page.expect_event('framenavigated')
           page.wait_for_load_state(state: 'domcontentloaded')
           messages << 'domcontentloaded'
         }
       ]
-      Concurrent::Promises.zip(*promises).value!
+      await_all(promises)
     end
     expect(messages).to eq(%w(route domcontentloaded clickload))
   end

--- a/spec/integration/page/basic_spec.rb
+++ b/spec/integration/page/basic_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 RSpec.describe Playwright::Page do
   it 'should reject all promises when page is closed' do
     with_page do |page|
-      never_resolved_promise = Concurrent::Promises.future { page.evaluate('() => new Promise(r => {})') }
-      sleep 0.5
+      never_resolved_promise = Playwright::AsyncEvaluation.new { page.evaluate('() => new Promise(r => {})') }
       page.close
       expect { never_resolved_promise.value! }.to raise_error(/Protocol error/)
     end
@@ -27,8 +26,8 @@ RSpec.describe Playwright::Page do
 
   it 'should terminate network waiters' do
     with_page do |page|
-      request_promise = Concurrent::Promises.future { page.expect_request('http://example.com/') }
-      response_promise = Concurrent::Promises.future { page.expect_response('http://example.com/') }
+      request_promise = Playwright::AsyncEvaluation.new { page.expect_request('http://example.com/') }
+      response_promise = Playwright::AsyncEvaluation.new { page.expect_response('http://example.com/') }
       page.close
       expect { request_promise.value! }.to raise_error(/Page closed/)
       expect { response_promise.value! }.to raise_error(/Page closed/)
@@ -47,7 +46,7 @@ RSpec.describe Playwright::Page do
 
   it 'should fire load when expected' do
     with_page do |page|
-      promise = Concurrent::Promises.future { page.expect_event('load') }
+      promise = Playwright::AsyncEvaluation.new { page.expect_event('load') }
       page.goto('about:blank')
       Timeout.timeout(1) do
         promise.value!
@@ -142,7 +141,7 @@ RSpec.describe Playwright::Page do
       new_page = page.expect_event('popup') do
         page.evaluate("() => window['newPage'] = window.open('about:blank')")
       end
-      closed_promise = Concurrent::Promises.resolvable_future
+      closed_promise = Playwright::AsyncValue.new
       new_page.once('close', -> { closed_promise.fulfill(nil) })
       page.evaluate("() => window['newPage'].close()")
       Timeout.timeout(1) do
@@ -154,7 +153,7 @@ RSpec.describe Playwright::Page do
   it 'page.close should work with page.close' do
     with_context do |context|
       page = context.new_page
-      closed_promise = Concurrent::Promises.resolvable_future
+      closed_promise = Playwright::AsyncValue.new
       page.once('close', -> { closed_promise.fulfill(nil) })
       page.close
       Timeout.timeout(1) do

--- a/spec/integration/page/dialog_spec.rb
+++ b/spec/integration/page/dialog_spec.rb
@@ -3,7 +3,7 @@ require 'spec_helper'
 RSpec.describe 'dialog' do
   it 'should fire' do
     with_page do |page|
-      dialog_promise = Concurrent::Promises.resolvable_future
+      dialog_promise = Playwright::AsyncValue.new
       page.once('dialog', ->(dialog) {
         dialog_promise.fulfill({
           type: dialog.type,
@@ -24,7 +24,7 @@ RSpec.describe 'dialog' do
 
   it 'should allow accepting prompts' do
     with_page do |page|
-      dialog_promise = Concurrent::Promises.resolvable_future
+      dialog_promise = Playwright::AsyncValue.new
       page.once('dialog', ->(dialog) {
         dialog_promise.fulfill({
           type: dialog.type,

--- a/spec/integration/page/route_spec.rb
+++ b/spec/integration/page/route_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe 'Page#route', sinatra: true do
   it 'should intercept' do
     with_page do |page|
       intercepted = false
-      promise = Concurrent::Promises.resolvable_future
+      promise = Playwright::AsyncValue.new
       request_frame_url = nil
       page.route('**/empty.html', ->(route, request) {
         promise.fulfill(request)

--- a/spec/integration/page/set_input_files_spec.rb
+++ b/spec/integration/page/set_input_files_spec.rb
@@ -44,9 +44,8 @@ RSpec.describe 'Page#set_input_files' do
   it 'should emit event once' do
     with_page do |page|
       page.content = '<input type=file>'
-      promise = Concurrent::Promises.resolvable_future
+      promise = Playwright::AsyncValue.new
       page.once('filechooser', -> (chooser) { promise.fulfill(chooser) })
-      sleep 0.5
       page.click('input')
       Timeout.timeout(2) do
         expect(promise.value!).to be_a(Playwright::FileChooser)
@@ -57,7 +56,7 @@ RSpec.describe 'Page#set_input_files' do
   it 'should emit event on/off' do
     with_page do |page|
       page.content = '<input type=file>'
-      promise = Concurrent::Promises.resolvable_future
+      promise = Playwright::AsyncValue.new
       listener = ->(chooser) {
         page.off(Playwright::Events::Page::FileChooser, listener)
         promise.fulfill(chooser)

--- a/spec/integration/page/wait_for_function_spec.rb
+++ b/spec/integration/page/wait_for_function_spec.rb
@@ -3,8 +3,7 @@ require 'spec_helper'
 RSpec.describe 'Page#wait_for_function' do
   it 'should accept a string' do
     with_page do |page|
-      watchdog = Concurrent::Promises.future { page.wait_for_function('window.__FOO === 1') }
-      sleep 0.5
+      watchdog = Playwright::AsyncEvaluation.new { page.wait_for_function('window.__FOO === 1') }
       page.evaluate("() => window['__FOO'] = 1")
       Timeout.timeout(2) { watchdog.value! }
     end
@@ -60,10 +59,9 @@ RSpec.describe 'Page#wait_for_function' do
 
   it 'should poll on raf' do
     with_page do |page|
-      watchdog = Concurrent::Promises.future {
+      watchdog = Playwright::AsyncEvaluation.new {
         page.wait_for_function("() => window['__FOO'] === 'hit'", polling: 'raf')
       }
-      sleep 0.5
       page.evaluate("() => window['__FOO'] = 'hit'")
       Timeout.timeout(2) { watchdog.value! }
     end
@@ -132,11 +130,10 @@ RSpec.describe 'Page#wait_for_function' do
       div = page.query_selector('div')
       resolved = false
 
-      promise = Concurrent::Promises.future {
+      promise = Playwright::AsyncEvaluation.new {
         page.wait_for_function('element => !element.parentElement', arg: div)
         resolved = true
       }
-      sleep 0.5
       expect {
         page.evaluate('element => element.remove()', arg: div)
         Timeout.timeout(1) { promise.value! }
@@ -165,8 +162,7 @@ RSpec.describe 'Page#wait_for_function' do
         return window['__injected'];
       }
       JAVASCRIPT
-      watchdog = Concurrent::Promises.future { page.wait_for_function(js, timeout: 0, polling: 10) }
-      sleep 0.5
+      watchdog = Playwright::AsyncEvaluation.new { page.wait_for_function(js, timeout: 0, polling: 10) }
       page.wait_for_function("() => window['__counter'] > 10")
       page.evaluate("() => window['__injected'] = true")
       Timeout.timeout(2) { watchdog.value! }

--- a/spec/playwright/async_evaluation_spec.rb
+++ b/spec/playwright/async_evaluation_spec.rb
@@ -1,0 +1,31 @@
+require 'spec_helper'
+require 'async'
+
+RSpec.describe Playwright::AsyncEvaluation do
+  around do |example|
+    Async { example.run }
+  end
+
+  it 'is not resolved on initialize' do
+    future = Playwright::AsyncEvaluation.new { |t| t.sleep 2 }
+    expect(future).not_to be_resolved
+    expect(future).not_to be_fulfilled
+    expect(future).not_to be_rejected
+  end
+
+  it 'is resolved on success' do
+    future = Playwright::AsyncEvaluation.new { 123 }
+    expect(future).to be_resolved
+    expect(future).to be_fulfilled
+    expect(future).not_to be_rejected
+    expect(future.value!).to eq(123)
+  end
+
+  it 'is rejected on error' do
+    future = Playwright::AsyncEvaluation.new { raise 'invalid' }
+    expect(future).to be_resolved
+    expect(future).not_to be_fulfilled
+    expect(future).to be_rejected
+    expect { future.value! }.to raise_error(/invalid/)
+  end
+end

--- a/spec/playwright/async_value_spec.rb
+++ b/spec/playwright/async_value_spec.rb
@@ -1,0 +1,63 @@
+require 'spec_helper'
+require 'async'
+
+RSpec.describe Playwright::AsyncValue do
+  around do |example|
+    Async { example.run }
+  end
+  let(:promise) { Playwright::AsyncValue.new }
+
+  it 'is not resolved on initialize' do
+    expect(promise).not_to be_resolved
+    expect(promise).not_to be_fulfilled
+    expect(promise).not_to be_rejected
+  end
+
+  it 'blocks until fulfilled' do
+    time_start = Time.now
+
+    Async { |t| t.sleep 2 ; promise.fulfill }
+    promise.value!
+
+    expect(Time.now - time_start).to be > 1
+  end
+
+  it 'blocks until rejected' do
+    time_start = Time.now
+
+    Async { |t| t.sleep 2 ; promise.reject("invalid") }
+    expect { promise.value! }.to raise_error(/invalid/)
+
+    expect(Time.now - time_start).to be > 1
+  end
+
+  it 'returns soon if already resolved' do
+    promise.fulfill
+
+    Timeout.timeout(1) { promise.value! }
+  end
+
+  it "doesn't raise on reject" do
+    expect { promise.reject("error!") }.not_to raise_error
+  end
+
+  it 'raises Rejection error for the result of reject' do
+    promise.reject("Error!")
+    expect { promise.value! }.to raise_error(Playwright::AsyncValue::Rejection)
+  end
+
+  it 'raises Rejection error for the result of reject' do
+    promise.reject(ArgumentError.new("invalid"))
+    expect { promise.value! }.to raise_error(ArgumentError)
+  end
+
+  it 'returns nil on fulfill without arg' do
+    promise.fulfill
+    Timeout.timeout(1) { expect(promise.value!).to be_nil }
+  end
+
+  it 'returns value on fulfill with arg' do
+    promise.fulfill(123)
+    Timeout.timeout(1) { expect(promise.value!).to eq(123) }
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@
 
 require 'bundler/setup'
 require 'playwright'
+require 'timeout'
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure
@@ -92,7 +93,6 @@ RSpec.configure do |config|
   config.around(sinatra: true) do |example|
     require 'net/http'
     require 'sinatra/base'
-    require 'timeout'
 
     sinatra_app = Sinatra.new
     sinatra_app.disable(:protection)


### PR DESCRIPTION
concurrent-ruby uses Thead for concurrent job execution. It often causes unexpected race condition, and we have to avoid it with `sleep 0.5` or something with best effot... It is really annoying.

playwright-ruby-client doesn't provide async APIs directly for users. So we can easily replace asynchrous architecture internally. Introduce https://github.com/socketry/async for better async. It is based on Fiber.
https://rubykaigi.org/2019/presentations/ioquatix.html


