### PR TITLE
Allow overriding sinatra static routes

### DIFF
--- a/spec/integration/download_spec.rb
+++ b/spec/integration/download_spec.rb
@@ -2,10 +2,8 @@ require 'spec_helper'
 require 'tmpdir'
 
 RSpec.describe 'download', sinatra: true do
-  let(:download_endpoint) { "/download-#{SecureRandom.hex(8)}"}
-  let(:download_with_filename_endpoint) { "/downloadWithFilename-#{SecureRandom.hex(8)}"}
   before {
-    sinatra.get(download_endpoint) do
+    sinatra.get('/download') do
       headers(
         'Content-Type' => 'application/octet-stream',
         'Content-Disposition' => 'attachment',
@@ -13,7 +11,7 @@ RSpec.describe 'download', sinatra: true do
       body('Hello world!')
     end
 
-    sinatra.get(download_with_filename_endpoint) do
+    sinatra.get('/downloadWithFilename') do
       headers(
         'Content-Type' => 'application/octet-stream',
         'Content-Disposition' => 'attachment; filename=file.txt',
@@ -24,12 +22,12 @@ RSpec.describe 'download', sinatra: true do
 
   it 'should report downloads with acceptDownloads: false' do
     with_page do |page|
-      page.content = "<a href=\"#{server_prefix}#{download_with_filename_endpoint}\">download</a>"
+      page.content = "<a href=\"#{server_prefix}/downloadWithFilename\">download</a>"
       download = page.expect_download do
         page.click('a')
       end
 
-      expect(download.url).to eq("#{server_prefix}#{download_with_filename_endpoint}")
+      expect(download.url).to eq("#{server_prefix}/downloadWithFilename")
       expect(download.suggested_filename).to eq('file.txt')
       expect { download.path }.to raise_error(/acceptDownloads: true/)
       expect(download.failure).to include('acceptDownloads')
@@ -38,7 +36,7 @@ RSpec.describe 'download', sinatra: true do
 
   it 'should report downloads with acceptDownloads: true' do
     with_page(acceptDownloads: true) do |page|
-      page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
+      page.content = "<a href=\"#{server_prefix}/download\">download</a>"
       download = page.expect_download do
         page.click('a')
       end
@@ -49,7 +47,7 @@ RSpec.describe 'download', sinatra: true do
 
   it 'should save to user-specified path' do
     with_page(acceptDownloads: true) do |page|
-      page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
+      page.content = "<a href=\"#{server_prefix}/download\">download</a>"
       download = page.expect_download do
         page.click('a')
       end
@@ -63,7 +61,7 @@ RSpec.describe 'download', sinatra: true do
 
   it 'should save to user-specified path without updating original path' do
     with_page(acceptDownloads: true) do |page|
-      page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
+      page.content = "<a href=\"#{server_prefix}/download\">download</a>"
       download = page.expect_download do
         page.click('a')
       end
@@ -280,7 +278,7 @@ RSpec.describe 'download', sinatra: true do
 
   it 'should delete file' do
     with_page(acceptDownloads: true) do |page|
-      page.content = "<a href=\"#{server_prefix}#{download_endpoint}\">download</a>"
+      page.content = "<a href=\"#{server_prefix}/download\">download</a>"
       download = page.expect_download do
         page.click('a')
       end

--- a/spec/integration/page/autowaiting_basic_spec.rb
+++ b/spec/integration/page/autowaiting_basic_spec.rb
@@ -1,16 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe 'autowaiting basic' do
-  let(:endpoint) { "/empty_#{SecureRandom.hex(24)}" }
   def init_server
     messages = []
 
-    sinatra.get(endpoint) do
+    sinatra.get('/empty.html') do
       messages << 'route'
       headers('Content-Type' => 'text/html')
       body("<link rel='stylesheet' href='./one-style.css'>")
     end
-    sinatra.post(endpoint) do
+    sinatra.post('/empty.html') do
       messages << 'route'
       headers('Content-Type' => 'text/html')
       body("<link rel='stylesheet' href='./one-style.css'>")
@@ -27,7 +26,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a id=\"anchor\" href=\"#{server_empty_page}\" >empty.html</a>"
 
       promises = [
         Playwright::AsyncEvaluation.new {
@@ -49,7 +48,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a id=\"anchor\" href=\"#{server_empty_page}\" >empty.html</a>"
 
       promises = [
         Playwright::AsyncEvaluation.new {
@@ -71,7 +70,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a id=\"anchor\" href=\"#{server_empty_page}\" >empty.html</a>"
 
       promises = [
         Playwright::AsyncEvaluation.new {
@@ -93,7 +92,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a id=\"anchor\" href=\"#{server_empty_page}\" >empty.html</a>"
       handle = page.evaluate_handle('document')
 
       promises = [
@@ -116,7 +115,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a id=\"anchor\" href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a id=\"anchor\" href=\"#{server_empty_page}\" >empty.html</a>"
       handle = page.query_selector('body')
 
       promises = [
@@ -139,7 +138,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a href=\"#{server_cross_process_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a href=\"#{server_cross_process_prefix}/empty.html\" >empty.html</a>"
 
       promises = [
         Playwright::AsyncEvaluation.new {
@@ -161,7 +160,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.content = "<a id=\"anchor\" href=\"#{server_cross_process_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a id=\"anchor\" href=\"#{server_cross_process_prefix}/empty.html\" >empty.html</a>"
 
       promises = [
         Playwright::AsyncEvaluation.new {
@@ -184,7 +183,7 @@ RSpec.describe 'autowaiting basic' do
 
     with_page do |page|
       html = <<~HTML
-      <form action="#{server_cross_process_prefix}#{endpoint}" method="get">
+      <form action="#{server_cross_process_prefix}/empty.html" method="get">
         <input name="foo" value="bar">
         <input type="submit" value="Submit">
       </form>
@@ -212,7 +211,7 @@ RSpec.describe 'autowaiting basic' do
 
     with_page do |page|
       html = <<~HTML
-      <form action="#{server_cross_process_prefix}#{endpoint}" method="post">
+      <form action="#{server_cross_process_prefix}/empty.html" method="post">
         <input name="foo" value="bar">
         <input type="submit" value="Submit">
       </form>
@@ -241,7 +240,7 @@ RSpec.describe 'autowaiting basic' do
     with_page do |page|
       promises = [
         Playwright::AsyncEvaluation.new {
-          page.evaluate("window.location.href = \"#{server_cross_process_prefix}#{endpoint}\"")
+          page.evaluate("window.location.href = \"#{server_cross_process_prefix}/empty.html\"")
           messages << 'evaluate'
         },
         Playwright::AsyncEvaluation.new {
@@ -258,13 +257,13 @@ RSpec.describe 'autowaiting basic' do
   it 'should await navigation when assigning location twice', sinatra: true do
     messages = []
 
-    sinatra.get("#{endpoint}/cancel") { 'done' }
-    sinatra.get("#{endpoint}/override") { messages << 'routeoverride' ; 'done' }
+    sinatra.get("/empty.html/cancel") { 'done' }
+    sinatra.get("/empty.html/override") { messages << 'routeoverride' ; 'done' }
 
     with_page do |page|
       js = <<~JAVASCRIPT
-      window.location.href = "#{server_cross_process_prefix}#{endpoint}/cancel";
-      window.location.href = "#{server_cross_process_prefix}#{endpoint}/override";
+      window.location.href = "#{server_cross_process_prefix}/empty.html/cancel";
+      window.location.href = "#{server_cross_process_prefix}/empty.html/override";
       JAVASCRIPT
 
       page.evaluate(js)
@@ -278,7 +277,7 @@ RSpec.describe 'autowaiting basic' do
     messages = init_server
 
     with_page do |page|
-      page.goto("#{server_prefix}#{endpoint}")
+      page.goto(server_empty_page)
       messages.clear
 
       promises = [
@@ -304,7 +303,7 @@ RSpec.describe 'autowaiting basic' do
 
     with_page do |page|
       html = <<~HTML
-      <a href="#{server_prefix}#{endpoint}" target=target>empty.html</a>
+      <a href="#{server_empty_page}" target=target>empty.html</a>
       <iframe name=target></iframe>
       HTML
       page.content = html
@@ -321,17 +320,17 @@ RSpec.describe 'autowaiting basic' do
         }
       ]
       await_all(promises)
-      expect(frame.url).to eq("#{server_prefix}#{endpoint}")
+      expect(frame.url).to eq(server_empty_page)
     end
 
     expect(messages).to eq(%w(route navigated click))
   end
 
   it 'should work with noWaitAfter: true', sinatra: true do
-    sinatra.get(endpoint) { sleep 30 }
+    sinatra.get('/empty.html') { sleep 30 }
 
     with_page do |page|
-      page.content = "<a href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a href=\"#{server_empty_page}\" >empty.html</a>"
 
       Timeout.timeout(3) do
         page.click('a', noWaitAfter: true)
@@ -340,10 +339,10 @@ RSpec.describe 'autowaiting basic' do
   end
 
   it 'should work with dblclick noWaitAfter: true', sinatra: true do
-    sinatra.get(endpoint) { sleep 30 }
+    sinatra.get('/empty.html') { sleep 30 }
 
     with_page do |page|
-      page.content = "<a href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a href=\"#{server_empty_page}\" >empty.html</a>"
 
       Timeout.timeout(3) do
         page.dblclick('a', noWaitAfter: true)
@@ -352,20 +351,10 @@ RSpec.describe 'autowaiting basic' do
   end
 
   it 'should work with waitForLoadState(load)', sinatra: true do
-    messages = []
-
-    css_path = "/one-style-#{SecureRandom.hex(12)}.css"
-    sinatra.get(endpoint) do
-      messages << 'route'
-      headers('Content-Type' => 'text/html')
-      body("<link rel='stylesheet' href='.#{css_path}'>")
-    end
-    sinatra.get(css_path) do
-      'a { font-size: 12pt }'
-    end
+    messages = init_server
 
     with_page do |page|
-      page.content = "<a href=\"#{server_prefix}#{endpoint}\" >empty.html</a>"
+      page.content = "<a href=\"#{server_empty_page}\" >empty.html</a>"
 
       promises = [
         Playwright::AsyncEvaluation.new {

--- a/spec/sinatra_spec.rb
+++ b/spec/sinatra_spec.rb
@@ -14,4 +14,11 @@ RSpec.describe 'sinatra: true' do
     uri = URI("#{server_prefix}/one-style.html")
     expect(Net::HTTP.get(uri)).to include('<div>hello, world!</div>')
   end
+
+  it 'can override static assets with dynamic route', sinatra: true do
+    sinatra.get('/one-style.html') { 'ONE STYLE '}
+
+    uri = URI("#{server_prefix}/one-style.html")
+    expect(Net::HTTP.get(uri)).to include('ONE STYLE')
+  end
 end

--- a/spec/sinatra_spec.rb
+++ b/spec/sinatra_spec.rb
@@ -21,4 +21,9 @@ RSpec.describe 'sinatra: true' do
     uri = URI("#{server_prefix}/one-style.html")
     expect(Net::HTTP.get(uri)).to include('ONE STYLE')
   end
+
+  it 'can revert routes', sinatra: true do
+    uri = URI("#{server_prefix}/one-style.html")
+    expect(Net::HTTP.get(uri)).not_to include('ONE STYLE')
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,7 +94,47 @@ RSpec.configure do |config|
     require 'net/http'
     require 'sinatra/base'
 
-    sinatra_app = Sinatra.new
+    class SinatraApp < Sinatra::Base
+      # Change the priority of static file routing.
+      # Original impl is here:
+      # https://github.com/sinatra/sinatra/blob/v2.1.0/lib/sinatra/base.rb
+      #
+      # Dispatch a request with error handling.
+      def dispatch!
+        # Avoid passing frozen string in force_encoding
+        @params.merge!(@request.params).each do |key, val|
+          next unless val.respond_to?(:force_encoding)
+          val = val.dup if val.frozen?
+          @params[key] = force_encoding(val)
+        end
+
+        invoke do
+          filter! :before do
+            @pinned_response = !@response['Content-Type'].nil?
+          end
+          route!
+          static! if settings.static? && (request.get? || request.head?)
+
+          route_missing_really!
+        end
+      rescue ::Exception => boom
+        invoke { handle_exception!(boom) }
+      ensure
+        begin
+          filter! :after unless env['sinatra.static_file']
+        rescue ::Exception => boom
+          invoke { handle_exception!(boom) } unless @env['sinatra.error']
+        end
+      end
+
+      alias_method :route_missing_really!, :route_missing
+
+      def route_missing
+        # Do nothing when called in #route!
+      end
+    end
+
+    sinatra_app = SinatraApp
     sinatra_app.disable(:protection)
     sinatra_app.set(:public_folder, File.join(__dir__, 'assets'))
     @server_prefix = "http://localhost:4567"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -94,7 +94,7 @@ RSpec.configure do |config|
     require 'net/http'
     require 'sinatra/base'
 
-    class SinatraApp < Sinatra::Base
+    sinatra_app = Class.new(Sinatra::Base) do
       # Change the priority of static file routing.
       # Original impl is here:
       # https://github.com/sinatra/sinatra/blob/v2.1.0/lib/sinatra/base.rb
@@ -134,7 +134,6 @@ RSpec.configure do |config|
       end
     end
 
-    sinatra_app = SinatraApp
     sinatra_app.disable(:protection)
     sinatra_app.set(:public_folder, File.join(__dir__, 'assets'))
     @server_prefix = "http://localhost:4567"


### PR DESCRIPTION
Sinatra::Base gives more priority to static routes than dynamic defined one.  So this definition below is ignored. This is inconvenient in our unit testing...

```
sinatra.get('/empty.html') { 'My Empty' }
```

Let's change the routing priority.