### PR TITLE
Revert introducing socketry/async

### DIFF
--- a/lib/playwright.rb
+++ b/lib/playwright.rb
@@ -3,8 +3,8 @@
 # namespace declaration
 module Playwright; end
 
-# socketry/async and wrappers.
-require 'async'
+# concurrent-ruby and its wrappers
+require 'concurrent'
 require 'playwright/async_evaluation'
 require 'playwright/async_value'
 
@@ -37,31 +37,40 @@ require 'playwright/playwright_api'
 Dir[File.join(__dir__, 'playwright_api', '*.rb')].each { |f| require f }
 
 module Playwright
-  module_function def create(playwright_cli_executable_path:, timeout: nil, &block)
+  # Recommended to call this method with block.
+  #
+  # Playwright.create(...) do |playwright|
+  #   browser = playwright.chromium.launch
+  #   ...
+  # end
+  #
+  # When we use this method without block, an instance of Puppeteer::Connection is returned
+  # and we *must* call connection.stop on the end.
+  # The instance of playwright is available by calling Playwright.instance
+  module_function def create(playwright_cli_executable_path:, &block)
     raise ArgumentError.new("block must be provided") unless block
 
     connection = Connection.new(playwright_cli_executable_path: playwright_cli_executable_path)
-    Async do
-      connection.async_run
+    connection.async_run
 
-      Async do |task|
-        playwright = connection.wait_for_object_with_known_name('Playwright')
-        playwright_api = PlaywrightApi.wrap(playwright)
+    begin
+      playwright = connection.wait_for_object_with_known_name('Playwright')
+      ::Playwright.instance_variable_set(:@playwright_instance, PlaywrightApi.wrap(playwright))
+    rescue
+      connection.stop
+      ::Playwright.instance_variable_set(:@playwright_instance, nil)
+      raise
+    end
 
-        ::Playwright.instance_variable_set(:@playwright_instance, playwright_api)
-
-        if timeout
-          task.with_timeout(timeout) do
-            block.call(playwright_api)
-          end
-        else
-          block.call(playwright_api)
-        end
+    if block
+      begin
+        block.call(::Playwright.instance)
       ensure
         connection.stop
-
         ::Playwright.instance_variable_set(:@playwright_instance, nil)
       end
+    else
+      connection
     end
   end
 

--- a/lib/playwright/async_evaluation.rb
+++ b/lib/playwright/async_evaluation.rb
@@ -1,28 +1,26 @@
-require 'async/condition'
-
 module Playwright
-  # Async { } wrapper, providing Concurrent::Promises::Future-like APIs
+  # wraps Concurrent::Promises.future
   class AsyncEvaluation
     def initialize(&block)
       raise ArgumentError.new('block must be given') unless block
 
-      @task = Async(&block)
+      @future = Concurrent::Promises.future(&block)
     end
 
     def resolved?
-      %i(complete stopped failed).include?(@task.status)
+      @future.resolved?
     end
 
     def fulfilled?
-      @task.status == :complete
+      @future.fulfilled?
     end
 
     def rejected?
-      %i(stopped failed).include?(@task.status)
+      @future.rejected?
     end
 
     def value!
-      @task.result
+      @future.value!
     end
   end
 end

--- a/lib/playwright/async_value.rb
+++ b/lib/playwright/async_value.rb
@@ -1,37 +1,27 @@
-require 'async/condition'
-
 module Playwright
-  # Async::Condition wrapper, providing Concurrent::Promises::Future-like APIs
+  # wraps Concurrent::Promises.resolvable_future
   class AsyncValue
     def initialize
-      @fulfilled = false
+      @future = Concurrent::Promises.resolvable_future
       @resolved = false
-      @value = nil
     end
 
-    def fulfill(value = nil)
-      raise ArgumentError.new('already resolved') if @resolved
+    class AlreadyResolvedError < StandardError ; end
 
-      @fulfilled = true
+    def fulfill(value = nil)
+      raise AlreadyResolvedError.new('already resolved') if @resolved
+
       @resolved = true
-      @value = value
-      @notification&.signal(@value)
+      @future.fulfill(value)
 
       nil
     end
 
-    class Rejection < StandardError ; end
-
     def reject(error)
-      raise ArgumentError.new('already resolved') if @resolved
+      raise AlreadyResolvedError.new('already resolved') if @resolved
 
       @resolved = true
-      if error.is_a?(StandardError)
-        @value = error
-      else
-        @value = Rejection.new(error)
-      end
-      @notification&.signal(@value)
+      @future.reject(error)
 
       nil
     end
@@ -41,27 +31,15 @@ module Playwright
     end
 
     def fulfilled?
-      @resolved && @fulfilled
+      @future.fulfilled?
     end
 
     def rejected?
-      @resolved && !@fulfilled
+      @future.rejected?
     end
 
     def value!
-      result = wait_for_value
-      if result.is_a?(StandardError)
-        raise result
-      else
-        result
-      end
-    end
-
-    private def wait_for_value
-      return @value if @resolved
-
-      @notification = Async::Condition.new
-      @notification.wait
+      @future.value!
     end
   end
 end

--- a/playwright.gemspec
+++ b/playwright.gemspec
@@ -24,8 +24,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'async'
-  spec.add_dependency 'async-io'
+  spec.add_dependency 'concurrent-ruby', '>= 1.1.6'
   spec.add_dependency 'mime-types', '>= 3.0'
   spec.add_development_dependency 'bundler', '~> 2.2.3'
   spec.add_development_dependency 'chunky_png'

--- a/spec/playwright/async_evaluation_spec.rb
+++ b/spec/playwright/async_evaluation_spec.rb
@@ -1,11 +1,6 @@
 require 'spec_helper'
-require 'async'
 
 RSpec.describe Playwright::AsyncEvaluation do
-  around do |example|
-    Async { example.run }
-  end
-
   it 'is not resolved on initialize' do
     future = Playwright::AsyncEvaluation.new { |t| t.sleep 2 }
     expect(future).not_to be_resolved

--- a/spec/playwright/async_value_spec.rb
+++ b/spec/playwright/async_value_spec.rb
@@ -1,10 +1,6 @@
 require 'spec_helper'
-require 'async'
 
 RSpec.describe Playwright::AsyncValue do
-  around do |example|
-    Async { example.run }
-  end
   let(:promise) { Playwright::AsyncValue.new }
 
   it 'is not resolved on initialize' do
@@ -16,7 +12,7 @@ RSpec.describe Playwright::AsyncValue do
   it 'blocks until fulfilled' do
     time_start = Time.now
 
-    Async { |t| t.sleep 2 ; promise.fulfill }
+    Thread.new { sleep 2 ; promise.fulfill }
     promise.value!
 
     expect(Time.now - time_start).to be > 1
@@ -25,7 +21,7 @@ RSpec.describe Playwright::AsyncValue do
   it 'blocks until rejected' do
     time_start = Time.now
 
-    Async { |t| t.sleep 2 ; promise.reject("invalid") }
+    Thread.new { sleep 2 ; promise.reject("invalid") }
     expect { promise.value! }.to raise_error(/invalid/)
 
     expect(Time.now - time_start).to be > 1

--- a/spec/playwright/chromium_spec.rb
+++ b/spec/playwright/chromium_spec.rb
@@ -3,16 +3,10 @@ require 'net/http'
 
 RSpec.describe 'chromium' do
   around do |example|
-    # Every integration test case should spend less than 15sec, in CI.
-    params = {
-      playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH'],
-      timeout: ENV['CI'] ? 15 : nil,
-    }
-
-    Playwright.create(**params) do |playwright|
+    Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
       @playwright_chromium = playwright.chromium
 
-      example.run
+      Timeout.timeout(5) { example.run }
     end
   end
   let(:browser_type) { @playwright_chromium }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,17 +36,18 @@ RSpec.configure do |config|
   config.around(:each, type: :integration) do |example|
     @playwright_browser_type = browser_type
 
-    # Every integration test case should spend less than 15sec, in CI.
-    params = {
-      playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH'],
-      timeout: ENV['CI'] ? 15 : nil,
-    }
-    Playwright.create(**params) do |playwright|
+    Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
       @playwright_playwright = playwright
 
       playwright.send(@playwright_browser_type).launch do |browser|
         @playwright_browser = browser
-        example.run
+
+        if ENV['CI']
+          # Every integration test case should spend less than 15sec, in CI.
+          Timeout.timeout(15) { example.run }
+        else
+          example.run
+        end
       end
     end
   end
@@ -167,17 +168,6 @@ RSpec.configure do |config|
       example.run
     ensure
       sinatra_app.quit!
-    end
-  end
-
-  # Every integration test case should spend less than 20sec, in CI.
-  #
-  # Essentially this timeout is not needed.
-  # However socketry/async doesn't raise StandardError, and hangs...!
-  # Workaround to do with it...
-  if ENV['CI']
-    config.around(:each, type: :integration) do |example|
-      Timeout.timeout(20) { example.run }
     end
   end
 end


### PR DESCRIPTION
reverts #45 

For implementing Capybara driver, we have to separate Playwright.create and its end process, without using block. (ref: https://github.com/socketry/async/issues/109 )
Also sometimes incomprehensible deadlock occured...

At this point, keep implementing with concurrent-ruby, at the cost of performance and flakyness.