### PR TITLE
cache Playwright API instance

### DIFF
--- a/lib/playwright/channel_owner.rb
+++ b/lib/playwright/channel_owner.rb
@@ -10,6 +10,9 @@ module Playwright
       channel&.object
     end
 
+    # hidden field for caching API instance.
+    attr_accessor :_api
+
     # @param parent [Playwright::ChannelOwner|Playwright::Connection]
     # @param type [String]
     # @param guid [String]

--- a/lib/playwright/playwright_api.rb
+++ b/lib/playwright/playwright_api.rb
@@ -31,7 +31,7 @@ module Playwright
       def wrap
         api_class = detect_class_for(@impl.class)
         if api_class
-          api_class.new(@impl)
+          @impl._api ||= api_class.new(@impl)
         else
           raise NotImplementedError.new("Playwright::#{expected_class_name_for(@impl.class)} is not implemented")
         end
@@ -99,10 +99,6 @@ module Playwright
     # @param impl [Playwright::ChannelOwner|Playwright::ApiImplementation]
     def initialize(impl)
       @impl = impl
-    end
-
-    def ==(other)
-      @impl.to_s == other.instance_variable_get(:'@impl').to_s
     end
 
     # @param block [Proc]

--- a/spec/integration/example_spec.rb
+++ b/spec/integration/example_spec.rb
@@ -61,4 +61,11 @@ RSpec.describe 'example' do
       expect(browser.contexts.map(&:pages).flatten.map(&:guid)).to include(page.guid)
     end
   end
+
+  it 'returns the same Playwright API instance for the same impl' do
+    with_page do |page|
+      expect(page.context.pages.last).to equal(page)
+      expect(browser.new_page).not_to equal(page)
+    end
+  end
 end


### PR DESCRIPTION
playwright-ruby-client uses generated API codes.

In current implementation, Playwright API instance is always generated for each channel owner reference.
So `page.context.pages.last` is not the same instance as `page`...
This implementation is not so good when extending Playwright::Page or Playwright::Browser.

This PR introduces the instance cache for Playwright API.