### PR TITLE
use md5 example instead of sha256

### DIFF
--- a/development/generate_api/example_codes.rb
+++ b/development/generate_api/example_codes.rb
@@ -120,16 +120,16 @@ module ExampleCodes
   def example_ec3ef36671a002a6e12799fc5321ff60647c20c3f42fbd712d06e1c58cef75f5(browser_context:)
     require 'digest'
 
-    def sha256(text)
-      Digest::SHA256.hexdigest(text)
+    def md5(text)
+      Digest::MD5.hexdigest(text)
     end
 
-    browser_context.expose_function("sha256", method(:sha256))
+    browser_context.expose_function("md5", method(:md5))
     page = browser_context.new_page()
     page.content = <<~HTML
     <script>
       async function onClick() {
-        document.querySelector('div').textContent = await window.sha256('PLAYWRIGHT');
+        document.querySelector('div').textContent = await window.md5('PLAYWRIGHT');
       }
     </script>
     <button onclick="onClick()">Click me</button>

--- a/development/generate_api/renderers/apidoc_renderer.rb
+++ b/development/generate_api/renderers/apidoc_renderer.rb
@@ -282,10 +282,6 @@ class ApidocRenderer
       convertion = {
         "If predicate is provided, it passes [Page](./page)\nvalue into the `predicate` function and waits for `predicate(event)` to return a truthy value." \
           => "If predicate is provided, it passes [Page](./page) value into the `predicate` and waits for `predicate.call(page)` to return a truthy value.",
-
-        # https://github.com/microsoft/playwright-python/issues/727
-        "An example of adding an `md5` function to all pages in the context" \
-          => "An example of adding an `sha256` function to all pages in the context"
       }
       convertion.inject(content) do |current, entry|
         str_from, str_to = entry

--- a/documentation/docs/api/browser_context.md
+++ b/documentation/docs/api/browser_context.md
@@ -193,21 +193,21 @@ If the `callback` returns a [Promise](https://developer.mozilla.org/en-US/docs/W
 
 See [Page#expose_function](./page#expose_function) for page-only version.
 
-An example of adding an `sha256` function to all pages in the context:
+An example of adding an `md5` function to all pages in the context:
 
 ```ruby
 require 'digest'
 
-def sha256(text)
-  Digest::SHA256.hexdigest(text)
+def md5(text)
+  Digest::MD5.hexdigest(text)
 end
 
-browser_context.expose_function("sha256", method(:sha256))
+browser_context.expose_function("md5", method(:md5))
 page = browser_context.new_page()
 page.content = <<~HTML
 <script>
   async function onClick() {
-    document.querySelector('div').textContent = await window.sha256('PLAYWRIGHT');
+    document.querySelector('div').textContent = await window.md5('PLAYWRIGHT');
   }
 </script>
 <button onclick="onClick()">Click me</button>


### PR DESCRIPTION
Officual Playwright documentation shows an example with `md5`. (ref: https://github.com/microsoft/playwright/pull/6805)

playwright-ruby-client documentation should be the same.
