### PR TITLE
fix expose_binding to work with ElementHandle

### DIFF
--- a/development/unimplemented_examples.md
+++ b/development/unimplemented_examples.md
@@ -501,6 +501,21 @@ frame.wait_for_url("**/target.html")
 
 ```
 
+### example_29716fdd4471a97923a64eebeee96330ab508226a496ae8fd13f12eb07d55ee6
+
+```
+def handle_worker(worker):
+    print("worker created: " + worker.url)
+    worker.on("close", lambda: print("worker destroyed: " + worker.url))
+
+page.on('worker', handle_worker)
+
+print("current workers:")
+for worker in page.workers:
+    print("    " + worker.url)
+
+```
+
 ### example_49f0cb9b5a21d0d5fe2b180c847bdb21068b335b4c2f42d5c05eb1957297899f
 
 ```

--- a/documentation/docs/api/worker.md
+++ b/documentation/docs/api/worker.md
@@ -4,4 +4,21 @@ sidebar_position: 10
 
 # Worker
 
-Not Implemented
+The Worker class represents a [WebWorker](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API). `worker`
+event is emitted on the page object to signal a worker creation. `close` event is emitted on the worker object when the
+worker is gone.
+
+```py title=example_29716fdd4471a97923a64eebeee96330ab508226a496ae8fd13f12eb07d55ee6.py
+def handle_worker(worker):
+    print("worker created: " + worker.url)
+    worker.on("close", lambda: print("worker destroyed: " + worker.url))
+
+page.on('worker', handle_worker)
+
+print("current workers:")
+for worker in page.workers:
+    print("    " + worker.url)
+
+```
+
+

--- a/documentation/docs/include/api_coverage.md
+++ b/documentation/docs/include/api_coverage.md
@@ -175,7 +175,7 @@
 * ~~wait_for_timeout~~
 * wait_for_url
 
-## ~~Worker~~
+## Worker
 
 * ~~evaluate~~
 * ~~evaluate_handle~~

--- a/lib/playwright/channel_owners/binding_call.rb
+++ b/lib/playwright/channel_owners/binding_call.rb
@@ -30,7 +30,7 @@ module Playwright
         end
 
       begin
-        result = callback.call(source, *args)
+        result = PlaywrightApi.unwrap(callback.call(source, *args))
         @channel.send_message_to_server('resolve', result: JavaScript::ValueSerializer.new(result).serialize)
       rescue => err
         @channel.send_message_to_server('reject', error: { error: { message: err.message, name: 'Error' }})

--- a/lib/playwright/channel_owners/worker.rb
+++ b/lib/playwright/channel_owners/worker.rb
@@ -1,0 +1,4 @@
+module Playwright
+  define_channel_owner :Worker do
+  end
+end

--- a/spec/integration/browser_context/expose_function_spec.rb
+++ b/spec/integration/browser_context/expose_function_spec.rb
@@ -25,10 +25,7 @@ RSpec.describe 'expose function' do
       page.expose_function('mul', ->(a, b) { a * b })
       context.expose_function('sub', ->(a, b) { a - b })
       context.expose_binding('addHandle', ->(source, a, b) {
-        # Original implementation uses evaluateHandle, but ElementHandle cannot be parsed.
-        # (JS implementation is very special...)
-        # source[:frame].evaluate_handle('([a, b]) => a + b', arg: [a, b])
-        source[:frame].evaluate('([a, b]) => a + b', arg: [a, b])
+        source[:frame].evaluate_handle('([a, b]) => a + b', arg: [a, b])
       })
       result = page.evaluate('(async () => ({ mul: await mul(9, 4), add: await add(9, 4), sub: await sub(9, 4), addHandle: await addHandle(5, 6) }))()')
       expect(result).to eq({ 'mul' => 36, 'add' => 13, 'sub' => 5, 'addHandle' => 11 })


### PR DESCRIPTION
When the evaluation result is Playwright::JSHandle, it should be unwrapped.