### PR TITLE
allow Browser#new_page and BrowserContext#new_page to call with block for auto-closing

### DIFF
--- a/documentation/docs/api/browser.md
+++ b/documentation/docs/api/browser.md
@@ -138,7 +138,8 @@ def new_page(
       storageState: nil,
       timezoneId: nil,
       userAgent: nil,
-      viewport: nil)
+      viewport: nil,
+      &block)
 ```
 
 Creates a new page in a new browser context. Closing this page will close the context as well.

--- a/documentation/docs/api/browser_context.md
+++ b/documentation/docs/api/browser_context.md
@@ -229,7 +229,7 @@ specified.
 ## new_page
 
 ```
-def new_page
+def new_page(&block)
 ```
 
 Creates a new page in the browser context.

--- a/lib/playwright/channel_owners/browser.rb
+++ b/lib/playwright/channel_owners/browser.rb
@@ -30,24 +30,28 @@ module Playwright
       @contexts << context
       context.browser = self
       context.options = params
+      return context unless block
 
-      if block
-        begin
-          block.call(context)
-        ensure
-          context.close
-        end
-      else
-        context
+      begin
+        block.call(context)
+      ensure
+        context.close
       end
     end
 
-    def new_page(**options)
+    def new_page(**options, &block)
       context = new_context(**options)
       page = context.new_page
       page.owned_context = context
       context.owner_page = page
-      page
+
+      return page unless block
+
+      begin
+        block.call(page)
+      ensure
+        page.close
+      end
     end
 
     def close

--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -113,10 +113,17 @@ module Playwright
     end
 
     # @returns [Playwright::Page]
-    def new_page
+    def new_page(&block)
       raise 'Please use browser.new_context' if @owner_page
       resp = @channel.send_message_to_server('newPage')
-      ChannelOwners::Page.from(resp)
+      page = ChannelOwners::Page.from(resp)
+      return page unless block
+
+      begin
+        block.call(page)
+      ensure
+        page.close
+      end
     end
 
     def cookies(urls: nil)

--- a/lib/playwright/channel_owners/browser_type.rb
+++ b/lib/playwright/channel_owners/browser_type.rb
@@ -11,15 +11,12 @@ module Playwright
     def launch(options, &block)
       resp = @channel.send_message_to_server('launch', options.compact)
       browser = ChannelOwners::Browser.from(resp)
+      return browser unless block
 
-      if block
-        begin
-          block.call(browser)
-        ensure
-          browser.close
-        end
-      else
-        browser
+      begin
+        block.call(browser)
+      ensure
+        browser.close
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -75,24 +75,14 @@ RSpec.configure do |config|
       unless @playwright_browser
         raise '@playwright_browser must not be null.'
       end
-      context = @playwright_browser.new_context(**kwargs)
-      begin
-        block.call(context)
-      ensure
-        context.close
-      end
+      @playwright_browser.new_context(**kwargs, &block)
     end
 
     def with_page(**kwargs, &block)
       unless @playwright_browser
         raise '@playwright_browser must not be null.'
       end
-      page = @playwright_browser.new_page(**kwargs)
-      begin
-        block.call(page)
-      ensure
-        page.close
-      end
+      @playwright_browser.new_page(**kwargs, &block)
     end
 
     def sleep_a_bit_for_race_condition


### PR DESCRIPTION
refs https://github.com/microsoft/playwright-python/pull/746

```
playwright.chromium.launch do |browser|
  browser.new_page do |page| # <--
    # play with Page 
  end
end
```