### PR TITLE
Implement BrowserType#launch_persistent_context

### DIFF
--- a/documentation/docs/api/browser_type.md
+++ b/documentation/docs/api/browser_type.md
@@ -96,6 +96,59 @@ differences between Chromium and Chrome.
 [This article](https://chromium.googlesource.com/chromium/src/+/lkgr/docs/chromium_browser_vs_google_chrome.md)
 describes some differences for Linux users.
 
+## launch_persistent_context
+
+```
+def launch_persistent_context(
+      userDataDir,
+      acceptDownloads: nil,
+      args: nil,
+      bypassCSP: nil,
+      channel: nil,
+      chromiumSandbox: nil,
+      colorScheme: nil,
+      deviceScaleFactor: nil,
+      devtools: nil,
+      downloadsPath: nil,
+      env: nil,
+      executablePath: nil,
+      extraHTTPHeaders: nil,
+      geolocation: nil,
+      handleSIGHUP: nil,
+      handleSIGINT: nil,
+      handleSIGTERM: nil,
+      hasTouch: nil,
+      headless: nil,
+      httpCredentials: nil,
+      ignoreDefaultArgs: nil,
+      ignoreHTTPSErrors: nil,
+      isMobile: nil,
+      javaScriptEnabled: nil,
+      locale: nil,
+      noViewport: nil,
+      offline: nil,
+      permissions: nil,
+      proxy: nil,
+      record_har_omit_content: nil,
+      record_har_path: nil,
+      record_video_dir: nil,
+      record_video_size: nil,
+      reducedMotion: nil,
+      screen: nil,
+      slowMo: nil,
+      timeout: nil,
+      timezoneId: nil,
+      tracesDir: nil,
+      userAgent: nil,
+      viewport: nil,
+      &block)
+```
+
+Returns the persistent browser context instance.
+
+Launches browser that uses persistent storage located at `userDataDir` and returns the only context. Closing this
+context will automatically close the browser.
+
 ## name
 
 ```

--- a/documentation/docs/include/api_coverage.md
+++ b/documentation/docs/include/api_coverage.md
@@ -340,7 +340,7 @@
 * connect_over_cdp
 * executable_path
 * launch
-* ~~launch_persistent_context~~
+* launch_persistent_context
 * name
 
 ## Playwright

--- a/spec/integration/default_browser_context_spec.rb
+++ b/spec/integration/default_browser_context_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe 'default browser context' do
+  # https://github.com/microsoft/playwright/blob/master/tests/defaultbrowsercontext-2.spec.ts
+  it 'should accept userDataDir' do
+    Dir.mktmpdir do |tmpdir|
+      browser_type.launch_persistent_context(tmpdir) do |context|
+        expect(Dir.glob(File.join(tmpdir, '*/**'))).not_to be_empty
+      end
+      expect(Dir.glob(File.join(tmpdir, '*/**'))).not_to be_empty
+    end
+  end
+
+  it 'should restore state from userDataDir', sinatra: true do
+    Dir.mktmpdir do |tmpdir|
+      browser_type.launch_persistent_context(tmpdir) do |context|
+        page = context.new_page
+        page.goto(server_empty_page)
+        page.evaluate("() => localStorage.hey = 'hello'")
+      end
+
+      browser_type.launch_persistent_context(tmpdir) do |context|
+        page = context.new_page
+        page.goto(server_empty_page)
+        expect(page.evaluate("() => localStorage.hey")).to eq('hello')
+      end
+    end
+
+    Dir.mktmpdir do |tmpdir|
+      browser_type.launch_persistent_context(tmpdir) do |context|
+        page = context.new_page
+        page.goto(server_empty_page)
+        expect(page.evaluate("() => localStorage.hey")).not_to eq('hello')
+      end
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -35,12 +35,13 @@ RSpec.configure do |config|
   end
 
   config.around(:each, type: :integration) do |example|
-    @playwright_browser_type = browser_type
+    @playwright_browser_type_param = browser_type
 
     Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
       @playwright_playwright = playwright
+      @playwright_browser_type = playwright.send(@playwright_browser_type_param)
 
-      playwright.send(@playwright_browser_type).launch do |browser|
+      @playwright_browser_type.launch do |browser|
         @playwright_browser = browser
 
         if ENV['CI']
@@ -56,6 +57,10 @@ RSpec.configure do |config|
   module IntegrationTestCaseMethods
     def playwright
       @playwright_playwright or raise NoMethodError.new('undefined method "playwright"')
+    end
+
+    def browser_type
+      @playwright_browser_type or raise NoMethodError.new('undefined method "browser_type"')
     end
 
     def browser
@@ -81,7 +86,7 @@ RSpec.configure do |config|
     end
   end
   BROWSER_TYPES.each do |type|
-    IntegrationTestCaseMethods.define_method("#{type}?") { @playwright_browser_type == type }
+    IntegrationTestCaseMethods.define_method("#{type}?") { @playwright_browser_type_param == type }
   end
   config.include IntegrationTestCaseMethods, type: :integration
 


### PR DESCRIPTION
Allow users to re-use a browser execution context.
ref: https://github.com/YusukeIwaki/playwright-ruby-client/issues/104#issuecomment-858286504

In most case it is not the best practice to re-use the execution context, but some users expect 'semi-automation' usage. (User authentication is manually done by hand, and then enjoy automation using the persisted login session)
https://stackoverflow.com/questions/61359929/start-browser-in-non-icognito-to-preserve-login
