### PR TITLE
Implement Page#expect_request_finished

### DIFF
--- a/documentation/docs/api/page.md
+++ b/documentation/docs/api/page.md
@@ -1328,6 +1328,16 @@ puts request.headers
 
 
 
+## expect_request_finished
+
+```
+def expect_request_finished(predicate: nil, timeout: nil, &block)
+```
+
+Performs action and waits for a [Request](./request) to finish loading. If predicate is provided, it passes [Request](./request) value into
+the `predicate` function and waits for `predicate(request)` to return a truthy value. Will throw an error if the page is
+closed before the [`event: Page.requestFinished`] event is fired.
+
 ## expect_response
 
 ```

--- a/documentation/docs/include/api_coverage.md
+++ b/documentation/docs/include/api_coverage.md
@@ -273,7 +273,7 @@
 * expect_navigation
 * expect_popup
 * expect_request
-* ~~expect_request_finished~~
+* expect_request_finished
 * expect_response
 * wait_for_selector
 * ~~wait_for_timeout~~

--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -759,6 +759,10 @@ module Playwright
       expect_event(Events::Page::Request, predicate: predicate, timeout: timeout, &block)
     end
 
+    def expect_request_finished(predicate: nil, timeout: nil, &block)
+      expect_event(Events::Page::RequestFinished, predicate: predicate, timeout: timeout, &block)
+    end
+
     def expect_response(urlOrPredicate, timeout: nil, &block)
       predicate =
         case urlOrPredicate

--- a/spec/integration/page/wait_for_request_finished_spec.rb
+++ b/spec/integration/page/wait_for_request_finished_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe 'Page#expect_request_finished' do
+  it 'should work', sinatra: true do
+    with_page do |page|
+      page.goto(server_empty_page)
+      request = page.expect_request_finished(predicate: ->(req) { req.url == "#{server_prefix}/digits/2.png"}) do
+        page.evaluate(<<~JAVASCRIPT)
+        () => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }
+        JAVASCRIPT
+      end
+      expect(request.url).to eq("#{server_prefix}/digits/2.png")
+    end
+  end
+
+  it 'should work without predicate', sinatra: true do
+    with_page do |page|
+      page.goto(server_empty_page)
+      page.content = '<a href="one-style.html">one-style</a>'
+      request = page.expect_request_finished do
+        page.click('a')
+      end
+      expect(request.url).to eq("#{server_prefix}/one-style.html")
+    end
+  end
+
+  it 'should respect timeout' do
+    with_page do |page|
+      expect { page.expect_request_finished(predicate: ->(req) { false }, timeout: 1) }.to raise_error(Playwright::TimeoutError)
+    end
+  end
+
+  it 'should respect default timeout' do
+    with_page do |page|
+      page.default_timeout = 1
+      expect { page.expect_request_finished(predicate: ->(req) { false }) }.to raise_error(Playwright::TimeoutError)
+    end
+  end
+
+  it 'should work with no timeout', sinatra: true do
+    with_page do |page|
+      page.goto(server_empty_page)
+      request = page.expect_request_finished(predicate: ->(req) { req.url == "#{server_prefix}/digits/2.png"}) do
+        page.evaluate(<<~JAVASCRIPT)
+        () => setTimeout(() => {
+          fetch('/digits/1.png');
+          fetch('/digits/2.png');
+          fetch('/digits/3.png');
+        }, 500)
+        JAVASCRIPT
+      end
+      expect(request.url).to eq("#{server_prefix}/digits/2.png")
+    end
+  end
+end


### PR DESCRIPTION
Playwright 1.12 introduced a new API `Page#expect_request_finished`.
Include it into playwright-ruby-client.