### PR TITLE
update documentation about HTML5 drag of capybara driver

### DIFF
--- a/documentation/docs/article/guides/rails_integration.md
+++ b/documentation/docs/article/guides/rails_integration.md
@@ -202,4 +202,4 @@ end
 
 * Playwright doesn't allow clicking invisible DOM elements or moving elements. `click` sometimes doesn't work as Selenium does. See the detail in https://playwright.dev/docs/actionability/
 * `current_window.maximize` and `current_window.fullscreen` work only on headful (non-headless) mode, as selenium driver does.
-* `Capybara::Node::Element#drag_to` does not accept `html5` parameter.
+* `Capybara::Node::Element#drag_to` does not accept `html5` parameter. HTML5 drag and drop is not fully supported in Playwright.


### PR DESCRIPTION
We can handle HTML5 drag/drop with Playwright 1.12.0 or later. (Special thanks to https://github.com/microsoft/playwright/pull/6207)

```ruby
  it 'drag and drop' do
    Capybara.app_host = 'https://www.w3schools.com'
    visit '/html/html5_draganddrop.asp'
    find('#drag1').drag_to(find('#div2'))
  end
```

This example works as expected with latest Chrome.

However when we execute https://github.com/teamcapybara/capybara/blob/master/lib/capybara/spec/session/node_spec.rb, it doesn't works as Capybara expects...

```
    #drag_to
      HTML5
        should HTML5 drag and drop an object
        should HTML5 drag and drop an object child
        should set clientX/Y in dragover events (FAILED - 1)
        should preserve clientX/Y from last dragover event (FAILED - 2)
        should not HTML5 drag and drop on a non HTML5 drop element
        should HTML5 drag and drop when scrolling needed (FAILED - 3)
        should drag HTML5 default draggable elements (FAILED - 4)
        should work with SortableJS (FAILED - 5)
        should drag HTML5 default draggable element child (FAILED - 6)
        should simulate a single held down modifier key
        should simulate multiple held down modifier keys
        should support key aliases
```

For example anchor links are draggable by default, but not draggable with Playwright.

This is difficult to explain for users. So just describe "not fully supported"