### PR TITLE
[EXPERIMENTAL] connect via WebSocket

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
           name: RSpec
           command: |
             ./playwright.sh run-server 8888 & \
-            DEBUG=1 PLAYWRIGHT_WS_ENDPOINT=ws://127.0.0.1:8888/ws \
+            DEBUG=1 PLAYWRIGHT_WS_ENDPOINT=ws://127.0.0.1:8888/ws PLAYWRIGHT_CLI_EXECUTABLE_PATH=./playwright.sh \
             xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration \
             --format RspecJunitFormatter \
             --out test_results/rspec.xml \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,7 +29,8 @@ jobs:
       - run:
           name: RSpec
           command: |
-            DEBUG=1 PLAYWRIGHT_CLI_EXECUTABLE_PATH=./playwright.sh \
+            ./playwright.sh run-server 8888 & \
+            DEBUG=1 PLAYWRIGHT_WS_ENDPOINT=ws://127.0.0.1:8888/ws \
             xvfb-run --auto-servernum --server-args="-screen 0 1280x960x24" -- bundle exec rspec spec/integration \
             --format RspecJunitFormatter \
             --out test_results/rspec.xml \

--- a/README.md
+++ b/README.md
@@ -159,6 +159,32 @@ end
 
 ```
 
+### Communicate with Playwright server
+
+If your environment doesn't accept installing browser or creating browser process, consider separating Ruby client and Playwright server.
+
+![structure](https://user-images.githubusercontent.com/11763113/124934448-ad4d0700-e03f-11eb-942e-b9f3282bb703.png)
+
+For launching Playwright server, just execute:
+
+```
+npx playwright install && npx playwright run-server 8080
+```
+
+and we can connect to the server with the code like this:
+
+```ruby
+Playwright.connect_to_playwright_server('ws://127.0.0.1:8080') do |playwright|
+  playwright.chromium.launch do |browser|
+    page = browser.new_page
+    page.goto('https://github.com/YusukeIwaki')
+    page.screenshot(path: './YusukeIwaki.png')
+  end
+end
+```
+
+When `Playwright.connect_to_playwright_server` is used, playwright_cli_executable_path is not required.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).

--- a/lib/playwright.rb
+++ b/lib/playwright.rb
@@ -81,8 +81,4 @@ module Playwright
       execution
     end
   end
-
-  module_function def instance
-    @playwright_instance
-  end
 end

--- a/lib/playwright.rb
+++ b/lib/playwright.rb
@@ -59,7 +59,44 @@ module Playwright
   # and we *must* call execution.stop on the end.
   # The instance of playwright is available by calling execution.playwright
   module_function def create(playwright_cli_executable_path:, &block)
-    connection = Connection.new(playwright_cli_executable_path: playwright_cli_executable_path)
+    transport = Transport.new(playwright_cli_executable_path: playwright_cli_executable_path)
+    connection = Connection.new(transport)
+    connection.async_run
+
+    execution =
+      begin
+        playwright = connection.wait_for_object_with_known_name('Playwright')
+        Execution.new(connection, PlaywrightApi.wrap(playwright))
+      rescue
+        connection.stop
+        raise
+      end
+
+    if block
+      begin
+        block.call(execution.playwright)
+      ensure
+        execution.stop
+      end
+    else
+      execution
+    end
+  end
+
+  # Connects to Playwright server, launched by `npx playwright run-server` via WebSocket transport.
+  #
+  # Playwright.connect_to_playwright_server(...) do |playwright|
+  #   browser = playwright.chromium.launch
+  #   ...
+  # end
+  #
+  # @experimental
+  module_function def connect_to_playwright_server(ws_endpoint, &block)
+    require 'playwright/web_socket'
+    require 'playwright/web_socket_transport'
+
+    transport = WebSocketTransport.new(ws_endpoint: ws_endpoint)
+    connection = Connection.new(transport)
     connection.async_run
 
     execution =

--- a/lib/playwright.rb
+++ b/lib/playwright.rb
@@ -92,7 +92,7 @@ module Playwright
   #
   # @experimental
   module_function def connect_to_playwright_server(ws_endpoint, &block)
-    require 'playwright/web_socket'
+    require 'playwright/web_socket_client'
     require 'playwright/web_socket_transport'
 
     transport = WebSocketTransport.new(ws_endpoint: ws_endpoint)

--- a/lib/playwright/connection.rb
+++ b/lib/playwright/connection.rb
@@ -5,10 +5,8 @@ module Playwright
   # https://github.com/microsoft/playwright-python/blob/master/playwright/_impl/_connection.py
   # https://github.com/microsoft/playwright-java/blob/master/playwright/src/main/java/com/microsoft/playwright/impl/Connection.java
   class Connection
-    def initialize(playwright_cli_executable_path:)
-      @transport = Transport.new(
-        playwright_cli_executable_path: playwright_cli_executable_path
-      )
+    def initialize(transport)
+      @transport = transport
       @transport.on_message_received do |message|
         dispatch(message)
       end

--- a/lib/playwright/transport.rb
+++ b/lib/playwright/transport.rb
@@ -8,7 +8,6 @@ module Playwright
   # ref: https://github.com/microsoft/playwright-python/blob/master/playwright/_impl/_transport.py
   class Transport
     # @param playwright_cli_executable_path [String] path to playwright-cli.
-    # @param debug [Boolean]
     def initialize(playwright_cli_executable_path:)
       @driver_executable_path = playwright_cli_executable_path
       @debug = ENV['DEBUG'].to_s == 'true' || ENV['DEBUG'].to_s == '1'

--- a/lib/playwright/web_socket.rb
+++ b/lib/playwright/web_socket.rb
@@ -1,0 +1,164 @@
+require 'openssl'
+require 'socket'
+
+begin
+  require 'websocket/driver'
+rescue LoadError
+  raise "websocket-driver is required. Add `gem 'websocket-driver'` to your Gemfile"
+end
+
+# ref: https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/connection/client_socket.rb
+# ref: https://github.com/cavalle/chrome_remote/blob/master/lib/chrome_remote/web_socket_client.rb
+module Playwright
+  class WebSocket
+    class SecureSocketFactory
+      def initialize(host, port)
+        @host = host
+        @port = port || 443
+      end
+
+      def create
+        tcp_socket = TCPSocket.new(@host, @port)
+        OpenSSL::SSL::SSLSocket.new(tcp_socket).tap(&:connect)
+      end
+    end
+
+    class DriverImpl # providing #url, #write(string)
+      def initialize(url)
+        @url = url
+
+        endpoint = URI.parse(url)
+        @socket =
+          if endpoint.scheme == 'wss'
+            SecureSocketFactory.new(endpoint.host, endpoint.port).create
+          else
+            TCPSocket.new(endpoint.host, endpoint.port)
+          end
+      end
+
+      attr_reader :url
+
+      def write(data)
+        @socket.write(data)
+      rescue Errno::EPIPE
+        raise EOFError.new('already closed')
+      rescue Errno::ECONNRESET
+        raise EOFError.new('closed by remote')
+      end
+
+      def readpartial(maxlen = 1024)
+        @socket.readpartial(maxlen)
+      rescue Errno::ECONNRESET
+        raise EOFError.new('closed by remote')
+      end
+
+      def disconnect
+        @socket.close
+      end
+    end
+
+    STATE_CONNECTING = 0
+    STATE_OPENED = 1
+    STATE_CLOSING = 2
+    STATE_CLOSED = 3
+
+    def initialize(url:, max_payload_size:)
+      @impl = DriverImpl.new(url)
+      @driver = ::WebSocket::Driver.client(@impl, max_length: max_payload_size)
+
+      setup
+    end
+
+    class TransportError < StandardError; end
+
+    private def setup
+      @ready_state = STATE_CONNECTING
+      @driver.on(:open) do
+        @ready_state = STATE_OPENED
+        handle_on_open
+      end
+      @driver.on(:close) do |event|
+        @ready_state = STATE_CLOSED
+        handle_on_close(reason: event.reason, code: event.code)
+      end
+      @driver.on(:error) do |event|
+        if !handle_on_error(error_message: event.message)
+          raise TransportError.new(event.message)
+        end
+      end
+      @driver.on(:message) do |event|
+        handle_on_message(event.data)
+      end
+    end
+
+    private def wait_for_data
+      @driver.parse(@impl.readpartial)
+    end
+
+    def start
+      @driver.start
+
+      Thread.new do
+        wait_for_data until @ready_state >= STATE_CLOSING
+      rescue EOFError
+        # Google Chrome was gone.
+        # We have nothing todo. Just finish polling.
+        if @ready_state < STATE_CLOSING
+          handle_on_close(reason: 'Going Away', code: 1001)
+        end
+      end
+    end
+
+    # @param message [String]
+    def send_text(message)
+      return if @ready_state >= STATE_CLOSING
+      @driver.text(message)
+    end
+
+    def close(code: 1000, reason: "")
+      return if @ready_state >= STATE_CLOSING
+      @ready_state = STATE_CLOSING
+      @driver.close(reason, code)
+    end
+
+    def on_open(&block)
+      @on_open = block
+    end
+
+    # @param block [Proc(reason: String, code: Numeric)]
+    def on_close(&block)
+      @on_close = block
+    end
+
+    # @param block [Proc(error_message: String)]
+    def on_error(&block)
+      @on_error = block
+    end
+
+    def on_message(&block)
+      @on_message = block
+    end
+
+    private def handle_on_open
+      @on_open&.call
+    end
+
+    private def handle_on_close(reason:, code:)
+      @on_close&.call(reason, code)
+      @impl.disconnect
+    end
+
+    private def handle_on_error(error_message:)
+      return false if @on_error.nil?
+
+      @on_error.call(error_message)
+      true
+    end
+
+    private def handle_on_message(data)
+      return if @ready_state != STATE_OPENED
+
+      @on_message&.call(data)
+    end
+  end
+end

--- a/lib/playwright/web_socket_client.rb
+++ b/lib/playwright/web_socket_client.rb
@@ -10,7 +10,7 @@ end
 # ref: https://github.com/rails/rails/blob/master/actioncable/lib/action_cable/connection/client_socket.rb
 # ref: https://github.com/cavalle/chrome_remote/blob/master/lib/chrome_remote/web_socket_client.rb
 module Playwright
-  class WebSocket
+  class WebSocketClient
     class SecureSocketFactory
       def initialize(host, port)
         @host = host

--- a/lib/playwright/web_socket_transport.rb
+++ b/lib/playwright/web_socket_transport.rb
@@ -56,7 +56,7 @@ module Playwright
     #
     # @note This method blocks until playwright-cli exited. Consider using Thread or Future.
     def async_run
-      ws = ::Playwright::WebSocket.new(
+      ws = WebSocketClient.new(
         url: @ws_endpoint,
         max_payload_size: 256 * 1024 * 1024, # 256MB
       )
@@ -65,7 +65,7 @@ module Playwright
         promise.fulfill(ws)
       end
       ws.on_error do |error_message|
-        promise.reject(::Playwright::WebSocket::TransportError.new(error_message))
+        promise.reject(WebSocketClient::TransportError.new(error_message))
       end
 
       # Some messages can be sent just after start, before setting @ws.on_message
@@ -81,7 +81,7 @@ module Playwright
         @on_driver_crashed&.call
       end
     rescue Errno::ECONNREFUSED => err
-      raise ::Playwright::WebSocket::TransportError.new(err)
+      raise WebSocketClient::TransportError.new(err)
     end
 
     private

--- a/lib/playwright/web_socket_transport.rb
+++ b/lib/playwright/web_socket_transport.rb
@@ -1,0 +1,86 @@
+# frozen_string_literal: true
+
+require 'json'
+
+module Playwright
+  # ref: https://github.com/microsoft/playwright-python/blob/master/playwright/_impl/_transport.py
+  class WebSocketTransport
+    # @param ws_endpoint [String] EndpointURL of WebSocket
+    def initialize(ws_endpoint:)
+      @ws_endpoint = ws_endpoint
+      @debug = ENV['DEBUG'].to_s == 'true' || ENV['DEBUG'].to_s == '1'
+    end
+
+    def on_message_received(&block)
+      @on_message = block
+    end
+
+    def on_driver_crashed(&block)
+      @on_driver_crashed = block
+    end
+
+    class AlreadyDisconnectedError < StandardError ; end
+
+    # @param message [Hash]
+    def send_message(message)
+      debug_send_message(message) if @debug
+      msg = JSON.dump(message)
+
+      @ws.send_text(msg)
+    rescue Errno::EPIPE, IOError
+      raise AlreadyDisconnectedError.new('send_message failed')
+    end
+
+    # Terminate playwright-cli driver.
+    def stop
+      @ws&.close
+    rescue EOFError => err
+      # ignore EOLError. The connection is already closed.
+    end
+
+    # Start `playwright-cli run-driver`
+    #
+    # @note This method blocks until playwright-cli exited. Consider using Thread or Future.
+    def async_run
+      ws = ::Playwright::WebSocket.new(
+        url: @ws_endpoint,
+        max_payload_size: 256 * 1024 * 1024, # 256MB
+      )
+      promise = Concurrent::Promises.resolvable_future
+      ws.on_open do
+        promise.fulfill(ws)
+      end
+      ws.on_error do |error_message|
+        promise.reject(::Playwright::WebSocket::TransportError.new(error_message))
+      end
+      ws.start
+      @ws = promise.value!
+      @ws.on_message do |data|
+        handle_on_message(data)
+      end
+      @ws.on_error do |error|
+        puts "[WebSocketTransport] error: #{error}"
+        @on_driver_crashed&.call
+      end
+    rescue Errno::ECONNREFUSED => err
+      raise ::Playwright::WebSocket::TransportError.new(err)
+    end
+
+    private
+
+    def handle_on_message(data)
+      obj = JSON.parse(data)
+
+      debug_recv_message(obj) if @debug
+      @on_message&.call(obj)
+    end
+
+    def debug_send_message(message)
+      puts "\x1b[33mSEND>\x1b[0m#{message}"
+    end
+
+    def debug_recv_message(message)
+      puts "\x1b[33mRECV>\x1b[0m#{message}"
+    end
+  end
+end

--- a/lib/playwright/web_socket_transport.rb
+++ b/lib/playwright/web_socket_transport.rb
@@ -67,11 +67,15 @@ module Playwright
       ws.on_error do |error_message|
         promise.reject(::Playwright::WebSocket::TransportError.new(error_message))
       end
-      ws.start
-      @ws = promise.value!
-      @ws.on_message do |data|
+
+      # Some messages can be sent just after start, before setting @ws.on_message
+      # So set this handler before ws.start.
+      ws.on_message do |data|
         handle_on_message(data)
       end
+
+      ws.start
+      @ws = promise.value!
       @ws.on_error do |error|
         puts "[WebSocketTransport] error: #{error}"
         @on_driver_crashed&.call

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,7 +37,7 @@ RSpec.configure do |config|
   config.around(:each, type: :integration) do |example|
     @playwright_browser_type_param = browser_type
 
-    Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH']) do |playwright|
+    block = ->(playwright) {
       @playwright_playwright = playwright
       @playwright_browser_type = playwright.send(@playwright_browser_type_param)
 
@@ -51,6 +51,12 @@ RSpec.configure do |config|
           example.run
         end
       end
+    }
+
+    if ENV['PLAYWRIGHT_WS_ENDPOINT']
+      Playwright.connect_to_playwright_server(ENV['PLAYWRIGHT_WS_ENDPOINT'], &block)
+    else
+      Playwright.create(playwright_cli_executable_path: ENV['PLAYWRIGHT_CLI_EXECUTABLE_PATH'], &block)
     end
   end
 


### PR DESCRIPTION
Playwright requires many dependencies for installing browsers and must be permitted to launch browser process via shell-exec.

![current](https://user-images.githubusercontent.com/11763113/124934388-9c9c9100-e03f-11eb-8f13-324afac3be2a.png)

Most web services developers would hesitate to allow web server to execute non-web (browser) process. Some other developers would have trouble with executing browser automation script on Alpine Linux.

By separating browser owners into Playwright server, Ruby environment can be more simple.

![structure](https://user-images.githubusercontent.com/11763113/124934448-ad4d0700-e03f-11eb-942e-b9f3282bb703.png)

We can now easily integrate Playwright into Rails application.