### PR TITLE
Page#pause

### DIFF
--- a/documentation/docs/api/page.md
+++ b/documentation/docs/api/page.md
@@ -776,6 +776,21 @@ def opener
 
 Returns the opener for popup pages and `null` for others. If the opener has been closed already the returns `null`.
 
+## pause
+
+```
+def pause
+```
+
+Pauses script execution. Playwright will stop executing the script and wait for the user to either press 'Resume' button
+in the page overlay or to call `playwright.resume()` in the DevTools console.
+
+User can inspect selectors or perform manual steps while paused. Resume will continue running the original script from
+the place it was paused.
+
+> NOTE: This method requires Playwright to be started in a headed mode, with a falsy `headless` value in the
+[BrowserType#launch](./browser_type#launch).
+
 ## pdf
 
 ```

--- a/documentation/docs/article/guides/inspector.md
+++ b/documentation/docs/article/guides/inspector.md
@@ -1,0 +1,31 @@
+---
+sidebar_position: 6
+---
+
+# Playwright inspector
+
+Playwright provides an useful inspector.
+https://playwright.dev/docs/inspector/
+
+## Overview
+
+```ruby {4,8}
+playwright.chromium.launch(headless: false) do |browser|
+  browser.new_context do |context|
+    # This method call should be put just after creating BrowserContext.
+    context.enable_debug_console!
+
+    page = context.new_pagè
+    page.goto('http://example.com/')
+    page.pause
+  end
+end
+```
+
+`page.pause` requires Playwright debug session, and it can be enabled by calling `BrowserContext#enable_debug_console!` in advance.
+
+Note that since Ruby is not officially supported in Playwright, many limitations exist. We CANNOT
+
+* Launch inspector via `PWDEBUG=1`
+* Debug without inspector UI (`PWDEBUG=console` is not working well)
+* Show Ruby code in inspector

--- a/documentation/docs/article/guides/playwright_on_alpine_linux.md
+++ b/documentation/docs/article/guides/playwright_on_alpine_linux.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 6
+sidebar_position: 7
 ---
 
 # Playwright on Alpine Linux

--- a/documentation/docs/article/guides/semi_automation.md
+++ b/documentation/docs/article/guides/semi_automation.md
@@ -14,7 +14,7 @@ Keep in mind repeatedly that persistent browser context is NOT RECOMMENDED for m
 
 ## Pause automation for manual operation
 
-`Page#pause` is not implemented yet, however we can use `binding.pry`  (with `pry-byebug` installed) instead.
+We can simply use `binding.pry`  (with `pry-byebug` installed).
 
 ```ruby {4}
 playwright.chromium.launch_persistent_context('./data/', headless: false) do |context|

--- a/documentation/docs/include/api_coverage.md
+++ b/documentation/docs/include/api_coverage.md
@@ -249,7 +249,7 @@
 * locator
 * main_frame
 * opener
-* ~~pause~~
+* pause
 * pdf
 * press
 * query_selector

--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -250,7 +250,32 @@ module Playwright
       raise unless safe_close_error?(err)
     end
 
+    # REMARK: enable_debug_console is playwright-ruby-client specific method.
+    def enable_debug_console!
+      # Ruby is not supported in Playwright officially,
+      # and causes error:
+      #
+      #  Error:
+      #  ===============================
+      #  Unsupported language: 'ruby'
+      #  ===============================
+      #
+      # So, launch inspector as Python app.
+      # NOTE: This should be used only for Page#pause at this moment.
+      @channel.send_message_to_server('recorderSupplementEnable', language: :python)
+      @debug_console_enabled = true
+    end
+
+    class DebugConsoleNotEnabledError < StandardError
+      def initialize
+        super('Debug console should be enabled in advance, by calling `browser_context.enable_debug_console!`')
+      end
+    end
+
     def pause
+      unless @debug_console_enabled
+        raise DebugConsoleNotEnabledError.new
+      end
       @channel.send_message_to_server('pause')
     end
 

--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -694,6 +694,10 @@ module Playwright
       @main_frame.wait_for_function(pageFunction, arg: arg, polling: polling, timeout: timeout)
     end
 
+    def pause
+      @browser_context.send(:pause)
+    end
+
     def pdf(
           displayHeaderFooter: nil,
           footerTemplate: nil,

--- a/spec/integration/page/pause_spec.rb
+++ b/spec/integration/page/pause_spec.rb
@@ -1,0 +1,26 @@
+require 'spec_helper'
+
+RSpec.describe 'Page#pause' do
+  it 'cannot pause without debug_console enabled', sinatra: true do
+    with_page do |page|
+      page.goto(server_empty_page)
+      expect { page.pause }.to raise_error(/calling `browser_context.enable_debug_console!`/)
+    end
+  end
+
+  it 'can pause and resume', sinatra: true do
+    skip 'works only in Headful mode.'
+
+    with_page do |page|
+      page.context.enable_debug_console!
+      page.goto(server_empty_page)
+      promise = Concurrent::Promises.future do
+        page.pause
+      end
+      sleep 1
+      expect(promise).not_to be_resolved
+      page.evaluate('() => playwright.resume()')
+      Timeout.timeout(1) { promise.value! }
+    end
+  end
+end


### PR DESCRIPTION
`binding.pry` is enough in most cases, however Playwright inspector is helpful. Some users want to use it.

```ruby
playwright.chromium.launch(headless: false) do |browser|
  browser.new_context do |context|
    # This method call should be put just after creating BrowserContext.
    context.enable_debug_console!

    page = context.new_pagè
    page.goto('http://example.com/')
    page.pause
  end
end
```