### PR TITLE
Implement Playwright.connect_to_browser_server

### DIFF
--- a/lib/playwright/channel_owners/playwright.rb
+++ b/lib/playwright/channel_owners/playwright.rb
@@ -30,6 +30,15 @@ module Playwright
       end.to_h
     end
 
+    # used only from Playwright#connect_to_browser_server
+    private def pre_launched_browser
+      unless @initializer['preLaunchedBrowser']
+        raise 'Malformed endpoint. Did you use launchServer method?'
+      end
+
+      ::Playwright::ChannelOwners::Browser.from(@initializer['preLaunchedBrowser'])
+    end
+
     private def parse_device_descriptor(descriptor)
       # This return value can be passed into Browser#new_context as it is.
       # ex:


### PR DESCRIPTION
`BrowserType#connect` is a method to connect to Browser server.
It requires playwright driver but not it is used in actual implementation. So in this library, the method is implemented as `Playwright#connect_to_browser_server`

ref: https://github.com/YusukeIwaki/playwright-python-remote/pull/2

server: (requires version after https://github.com/microsoft/playwright/pull/8353)

```js
const playwright = require('playwright')

option = {
  channel: 'chrome-canary',
  headless: false,
  port: 8080,
  wsPath: 'ws',
}
playwright.chromium.launchServer(option).then((server) => { console.log(server.wsEndpoint()) })
```

```ruby
Playwright.connect_to_browser_server('ws://127.0.0.1:8080/ws') do |browser|
  page = browser.new_page
  page.goto('https://github.com/YusukeIwaki')
  page.screenshot(path: 'YusukeIwaki.png')
end
```