### PR TITLE
suppress warning: suppress warning: browser_context.rb:162: warning: instance variable @owner_page not initialized

### DIFF
--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -158,7 +158,7 @@ module Playwright
 
     # @returns [Playwright::Page]
     def new_page(&block)
-      raise 'Please use browser.new_context' if @owner_page
+      raise 'Please use browser.new_context' if defined?(@owner_page) && @owner_page
       resp = @channel.send_message_to_server('newPage')
       page = ChannelOwners::Page.from(resp)
       return page unless block


### PR DESCRIPTION
suppress the warning if method 'new_page'  is called before 'owner_page'.  
playwright-ruby-client-1.20.0/lib/playwright/channel_owners/browser_context.rb:162: warning: instance variable @owner_page not initialized