### PR TITLE
suppress some warnings

### DIFF
--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -171,14 +171,6 @@ module Playwright
     end
 
     def cookies(urls: nil)
-      target_urls =
-        if urls.nil?
-          []
-        elsif urls.is_a?(Enumerable)
-          urls
-        else
-          [urls]
-        end
       @channel.send_message_to_server('cookies', urls: urls)
     end
 
@@ -216,15 +208,6 @@ module Playwright
     end
 
     def add_init_script(path: nil, script: nil)
-      source =
-        if path
-          File.read(path)
-        elsif script
-          script
-        else
-          raise ArgumentError.new('Either path or script parameter must be specified')
-        end
-
       @channel.send_message_to_server('addInitScript', source: script)
       nil
     end

--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -377,15 +377,6 @@ module Playwright
     end
 
     def add_init_script(path: nil, script: nil)
-      source =
-        if path
-          File.read(path)
-        elsif script
-          script
-        else
-          raise ArgumentError.new('Either path or script parameter must be specified')
-        end
-
       @channel.send_message_to_server('addInitScript', source: script)
       nil
     end

--- a/lib/playwright/javascript/value_parser.rb
+++ b/lib/playwright/javascript/value_parser.rb
@@ -24,21 +24,19 @@ module Playwright
         end
 
         if hash.key?('v')
-          return
-            case hash['v']
-            when 'undefined'
-              nil
-            when 'null'
-              nil
-            when 'NaN'
-              Float::NAN
-            when 'Infinity'
-              Float::INFINITY
-            when '-Infinity'
-              -Float::INFINITY
-            when '-0'
-              -0
-            end
+          return case hash['v']
+                 when 'undefined'
+                  nil
+                 when 'null'
+                  nil
+                 when 'NaN'
+                  Float::NAN
+                 when 'Infinity'
+                  Float::INFINITY
+                 when '-Infinity'
+                  -Float::INFINITY when '-0'
+                  -0
+                 end
         end
 
         if hash.key?('d')

--- a/lib/playwright/transport.rb
+++ b/lib/playwright/transport.rb
@@ -46,7 +46,6 @@ module Playwright
     #
     # @note This method blocks until playwright-cli exited. Consider using Thread or Future.
     def async_run
-      popen3_args = {}
       @stdin, @stdout, @stderr, @thread = run_driver_with_open3
       @stdin.binmode  # Ensure Strings are written 1:1 without encoding conversion, necessary for integer values
 


### PR DESCRIPTION
I tried to remove the unused fragments and possible mismatch of warnings parser at return with parameter starting at next line

playwright-ruby-client-1.20.0/lib/playwright/javascript/value_parser.rb:28: warning: statement not reached
playwright-ruby-client-1.20.0/lib/playwright/channel_owners/browser_context.rb:174: warning: assigned but unused variable - target_urls
playwright-ruby-client-1.20.0/lib/playwright/channel_owners/browser_context.rb:219: warning: assigned but unused variable - source
playwright-ruby-client-1.20.0/lib/playwright/channel_owners/page.rb:380: warning: assigned but unused variable - source
playwright-ruby-client-1.20.0/lib/playwright/transport.rb:49: warning: assigned but unused variable - popen3_args