### PR TITLE
fix BrowserContext#add_init_script and Page#add_init_script to work

### DIFF
--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -226,7 +226,7 @@ module Playwright
           raise ArgumentError.new('Either path or script parameter must be specified')
         end
 
-      @channel.send_message_to_server('addInitScript', source: script)
+      @channel.send_message_to_server('addInitScript', source: source)
       nil
     end
 

--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -386,7 +386,7 @@ module Playwright
           raise ArgumentError.new('Either path or script parameter must be specified')
         end
 
-      @channel.send_message_to_server('addInitScript', source: script)
+      @channel.send_message_to_server('addInitScript', source: source)
       nil
     end
 

--- a/spec/integration/browser_context/add_init_script_spec.rb
+++ b/spec/integration/browser_context/add_init_script_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe 'BrowserContext#add_init_script',  sinatra: true do
+  it 'should work with browser context scripts' do
+    with_context do |context|
+      context.add_init_script(script: "window['injected'] = 123;")
+      page = context.new_page
+      page.goto("#{server_prefix}/tamperable.html")
+      result = page.evaluate("() => window['result']")
+      expect(result).to eq(123)
+    end
+  end
+
+  it 'should work without navigation in popup' do
+    with_context do |context|
+      context.add_init_script(script: "window['temp'] = 123")
+      page = context.new_page
+      popup = page.expect_popup do
+        page.evaluate("() => window['win'] = window.open()")
+      end
+      expect(popup.evaluate("() => window['temp']")).to eq(123)
+    end
+  end
+
+  it 'should work with browser context scripts with a path ' do
+    with_context do |context|
+      context.add_init_script(path: File.join('spec', 'assets', 'injectedfile.js'))
+      page = context.new_page
+      page.goto("#{server_prefix}/tamperable.html")
+      result = page.evaluate("() => window['result']")
+      expect(result).to eq(123)
+    end
+  end
+
+  it 'should work with browser context scripts for already created pages' do
+    with_context do |context|
+      page = context.new_page
+      context.add_init_script(script: "window['temp'] = 123")
+      page.add_init_script(script: "window['injected'] = window['temp']")
+      page.goto("#{server_prefix}/tamperable.html")
+      result = page.evaluate("() => window['result']")
+      expect(result).to eq(123)
+    end
+  end
+end

--- a/spec/integration/page/add_init_script_spec.rb
+++ b/spec/integration/page/add_init_script_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+RSpec.describe 'Page#add_init_script',  sinatra: true do
+  it 'should evaluate before anything else on the page' do
+    with_page do |page|
+      page.add_init_script(script: "window['injected'] = 123;")
+      page.goto("#{server_prefix}/tamperable.html")
+      result = page.evaluate("() => window['result']")
+      expect(result).to eq(123)
+    end
+  end
+
+  it 'should work with a path' do
+    with_page do |page|
+      page.add_init_script(path: File.join('spec', 'assets', 'injectedfile.js'))
+      page.goto("#{server_prefix}/tamperable.html")
+      result = page.evaluate("() => window['result']")
+      expect(result).to eq(123)
+    end
+  end
+
+  it 'should throw without path and script' do
+    with_page do |page|
+      expect {
+        page.add_init_script
+      }.to raise_error(/Either path or script parameter must be specified/)
+    end
+  end
+
+  it 'should support multiple scripts' do
+    with_page do |page|
+      page.add_init_script(script: "window['script1'] = 1")
+      page.add_init_script(script: "window['script2'] = 2")
+      page.goto("#{server_prefix}/tamperable.html")
+      expect(page.evaluate("() => window['script1']")).to eq(1)
+      expect(page.evaluate("() => window['script2']")).to eq(2)
+    end
+  end
+end


### PR DESCRIPTION
```
     Failure/Error: async_send_message_to_server(guid, method, params, metadata: metadata).value!
     
     Playwright::Error:
       Error: source: expected string, got object
```


found by https://github.com/YusukeIwaki/playwright-ruby-client/pull/208