### PR TITLE
Fix typo in docs homepage (relyable -> reliable)

### DIFF
--- a/documentation/src/components/HomepageFeatures.js
+++ b/documentation/src/components/HomepageFeatures.js
@@ -13,7 +13,7 @@ const FeatureList = [
     ),
   },
   {
-    title: 'Make more relyable tests',
+    title: 'Make more reliable tests',
     Svg: require('../../static/img/undraw_dropdown_menu.svg').default,
     description: (
       <>


### PR DESCRIPTION
Fixes minor typo on the doc homepage. Thanks for your work on this!