### PR TITLE
Add serviceWorkers to rails integration documentation

### DIFF
--- a/documentation/docs/article/guides/rails_integration.md
+++ b/documentation/docs/article/guides/rails_integration.md
@@ -95,6 +95,7 @@ These parameters can be passed into `Capybara::Playwright::Driver.new`
   * record_video_dir
   * record_video_size
   * screen
+  * serviceWorkers
   * storageState
   * timezoneId
   * userAgent


### PR DESCRIPTION
Adds serviceWorkers documentation to rails integration https://playwright-ruby-client.vercel.app/docs/api/browser#new_context

serviceWorkers is added as a page option to capybara-playwright-driver in this PR https://github.com/YusukeIwaki/capybara-playwright-driver/pull/53