### PR TITLE
[1.28.1] Make event emitter async for 'response' and 'dialog' event

### DIFF
--- a/development/generate_api/example_codes.rb
+++ b/development/generate_api/example_codes.rb
@@ -398,7 +398,7 @@ module ExampleCodes
     def handle_dialog(dialog)
       puts "[#{dialog.type}] #{dialog.message}"
       if dialog.message =~ /foo/
-        dialog.accept_async
+        dialog.accept
       else
         dialog.dismiss
       end

--- a/documentation/docs/api/dialog.md
+++ b/documentation/docs/api/dialog.md
@@ -12,7 +12,7 @@ An example of using [Dialog](./dialog) class:
 def handle_dialog(dialog)
   puts "[#{dialog.type}] #{dialog.message}"
   if dialog.message =~ /foo/
-    dialog.accept_async
+    dialog.accept
   else
     dialog.dismiss
   end

--- a/lib/playwright/event_emitter.rb
+++ b/lib/playwright/event_emitter.rb
@@ -38,7 +38,7 @@ module Playwright
     def emit(event, *args)
       handled = false
       (@__event_emitter ||= {})[event.to_s]&.each do |callback|
-        callback.call(*args)
+        perform_event_emitter_callback(event, callback, args)
         handled = true
       end
       handled
@@ -46,6 +46,11 @@ module Playwright
 
     private def listener_count(event)
       ((@__event_emitter ||= {})[event.to_s] ||= Set.new).count
+    end
+
+    # can be overriden
+    private def perform_event_emitter_callback(event, callback, args)
+      callback.call(*args)
     end
 
     # @param event [String]

--- a/playwright.gemspec
+++ b/playwright.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.4'
   spec.add_dependency 'concurrent-ruby', '>= 1.1.6'
   spec.add_dependency 'mime-types', '>= 3.0'
-  spec.add_development_dependency 'bundler', '~> 2.3.0'
+  spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'chunky_png'
   spec.add_development_dependency 'dry-inflector'
   spec.add_development_dependency 'faye-websocket'

--- a/spec/integration/page/dialog_spec.rb
+++ b/spec/integration/page/dialog_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'dialog' do
           default_value: dialog.default_value,
           message: dialog.message,
         })
-        dialog.accept_async
+        dialog.accept
       })
       page.evaluate('() => alert("yo")')
 
@@ -31,7 +31,7 @@ RSpec.describe 'dialog' do
           default_value: dialog.default_value,
           message: dialog.message,
         })
-        dialog.accept_async(promptText: 'answer!')
+        dialog.accept(promptText: 'answer!')
       })
       result = page.evaluate("() => prompt('question?', 'yes.')")
 
@@ -54,7 +54,7 @@ RSpec.describe 'dialog' do
 
   it 'should accept the confirm prompt' do
     with_page do |page|
-      page.once('dialog', ->(dialog) { dialog.accept_async })
+      page.once('dialog', ->(dialog) { dialog.accept })
       result = page.evaluate("() => confirm('boolean?')")
       expect(result).to eq(true)
     end
@@ -70,7 +70,7 @@ RSpec.describe 'dialog' do
 
   it 'should handle multiple alerts' do
     with_page do |page|
-      page.on('dialog', ->(dialog) { dialog.accept_async })
+      page.on('dialog', ->(dialog) { dialog.accept })
       page.content = <<~HTML
         <p>Hello World</p>
         <script>
@@ -86,7 +86,7 @@ RSpec.describe 'dialog' do
 
   it 'should handle multiple confirms' do
     with_page do |page|
-      page.on('dialog', ->(dialog) { dialog.accept_async })
+      page.on('dialog', ->(dialog) { dialog.accept })
       page.content = <<~HTML
         <p>Hello World</p>
         <script>

--- a/spec/integration/page/response_misc_spec.rb
+++ b/spec/integration/page/response_misc_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+RSpec.describe 'response' do
+  it 'https://github.com/YusukeIwaki/playwright-ruby-client/issues/227', sinatra: true do
+    sinatra.get('/test') do
+      'TEST-123'
+    end
+
+    with_page do |page|
+      response_promise = Concurrent::Promises.resolvable_future
+      page.on("response", -> (response) { response_promise.fulfill(response.body) })
+      page.goto("#{server_prefix}/test")
+      expect(response_promise.value!).to eq('TEST-123')
+    end
+  end
+end

--- a/spec/integration/page/route_spec.rb
+++ b/spec/integration/page/route_spec.rb
@@ -717,9 +717,7 @@ RSpec.describe 'Page#route', sinatra: true do
       page.route(
         '**/*',
         ->(route, req) {
-          Concurrent::Promises.future(req) do |_req|
-            headers_promise.fulfill(_req.all_headers)
-          end
+          headers_promise.fulfill(req.all_headers)
           route.continue
         },
       )


### PR DESCRIPTION
resolves #227 backport for 1.28.0