### PR TITLE
Fix the NoMethodError from #trace_discarded

### DIFF
--- a/lib/playwright/channel_owners/local_utils.rb
+++ b/lib/playwright/channel_owners/local_utils.rb
@@ -43,7 +43,7 @@ module Playwright
       @channel.send_message_to_server('tracingStarted', params)
     end
 
-    def tracing_discarded(stacks_id)
+    def trace_discarded(stacks_id)
       @channel.send_message_to_server('traceDiscarded', stacksId: stacks_id)
     end
 


### PR DESCRIPTION
There seems to be two places where the `trace_discarded` method is called:

https://github.com/YusukeIwaki/playwright-ruby-client/blob/c430525a5c5afc373c18b1a86832cb5c4723fd29/lib/playwright/channel_owners/tracing.rb#L47-L49

https://github.com/YusukeIwaki/playwright-ruby-client/blob/c430525a5c5afc373c18b1a86832cb5c4723fd29/lib/playwright/channel_owners/tracing.rb#L71-L73

However, the actual `LocalUtils` class only implements trac**ing**_discarded (`tracing` as opposed to `trace`). Not sure how I could this test this, so just opening up a draft PR and letting you know about this. Feel free to close this once this is fixed.