### PR TITLE
Alias [] to LocatorImpl#get_attribute

### DIFF
--- a/lib/playwright/locator_impl.rb
+++ b/lib/playwright/locator_impl.rb
@@ -319,6 +319,8 @@ module Playwright
       @frame.get_attribute(@selector, name, strict: true, timeout: timeout)
     end
 
+    alias_method :[], :get_attribute
+
     def hover(
           force: nil,
           modifiers: nil,

--- a/spec/integration/page/locator/list_spec.rb
+++ b/spec/integration/page/locator/list_spec.rb
@@ -3,10 +3,13 @@ require 'spec_helper'
 RSpec.describe 'Locator' do
   it 'locator.all should work' do
     with_page do |page|
-      page.content = "<div><p>A</p><p>B</p><p>C</p></div>"
+      page.content = "<div><p id='a'>A</p><p id='b'>B</p><p id='c'>C</p></div>"
 
       texts = page.locator('div >> p').all.map(&:text_content)
       expect(texts).to eq(%w[A B C])
+
+      ids = page.locator('div >> p').all.map { |p| p['id'] }
+      expect(ids).to eq(%w[a b c])
 
       expect(page.locator('span').all.to_a).to be_empty
     end


### PR DESCRIPTION
This allows you to say `page.locator("a[href]").all.map { |a| a["href"] }` as a natural analogy from `page.locator("a#id[href]")["href"]`.