### PR TITLE
Fix CI flures on Ruby <= 2.5

### DIFF
--- a/playwright.gemspec
+++ b/playwright.gemspec
@@ -33,8 +33,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'faye-websocket'
   spec.add_development_dependency 'pry-byebug'
   spec.add_development_dependency 'puma'
+  spec.add_development_dependency 'rack', '< 3'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop-rspec'
-  spec.add_development_dependency 'sinatra', '3.2.0'
+  spec.add_development_dependency 'sinatra'
 end


### PR DESCRIPTION
https://github.com/YusukeIwaki/playwright-ruby-client/pull/277/commits/633019e208a766ef506a970e5ae6ab85e0324325 this commit broke the compatibility with Ruby 2.4, 2.5.
Fix it.