### PR TITLE
throw ArgumentError when value provided to locator assertions is not a string or regex

### DIFF
--- a/lib/playwright/locator_assertions_impl.rb
+++ b/lib/playwright/locator_assertions_impl.rb
@@ -99,6 +99,8 @@ module Playwright
             }
           elsif item.is_a?(Regexp)
             expected_regex(item, match_substring, normalize_white_space, ignore_case)
+          else
+            raise ArgumentError.new("Expected value provided to assertion to be a string or regex, got #{item.class}")
           end
       end
     end

--- a/spec/playwright/locator_assertion_impl_spec.rb
+++ b/spec/playwright/locator_assertion_impl_spec.rb
@@ -1,0 +1,54 @@
+require 'spec_helper'
+
+RSpec.describe Playwright::LocatorAssertionsImpl do
+  describe '#to_expected_text_values' do
+    let(:instance) { described_class.new(nil, nil, nil, nil) }
+
+    it 'returns an empty array when items do not respond to :each' do
+      expect(instance.send(:to_expected_text_values, nil)).to eq([])
+    end
+
+    it 'returns an array of hashes for strings' do
+      items = %w[test example]
+      expected = [
+        { string: 'test', matchSubstring: false, normalizeWhiteSpace: false },
+        { string: 'example', matchSubstring: false, normalizeWhiteSpace: false }
+      ]
+      expect(instance.send(:to_expected_text_values, items)).to eq(expected)
+    end
+
+    it 'returns an array of hashes for regex patterns' do
+      items = [/test/, /example/]
+      expected = [
+        { regexSource: 'test', regexFlags: '', matchSubstring: false, normalizeWhiteSpace: false, ignoreCase: false },
+        { regexSource: 'example', regexFlags: '', matchSubstring: false, normalizeWhiteSpace: false, ignoreCase: false }
+      ]
+      expect(instance.send(:to_expected_text_values, items)).to eq(expected)
+    end
+
+    it 'returns an array of hashes for mixed strings and regex patterns' do
+      items = ['test', /example/]
+      expected = [
+        { string: 'test', matchSubstring: false, normalizeWhiteSpace: false },
+        { regexSource: 'example', regexFlags: '', matchSubstring: false, normalizeWhiteSpace: false, ignoreCase: false }
+      ]
+      expect(instance.send(:to_expected_text_values, items)).to eq(expected)
+    end
+
+    it 'handles ignore_case flag correctly' do
+      items = ['test', /example/]
+      expected = [
+        { string: 'test', matchSubstring: false, normalizeWhiteSpace: false, ignoreCase: true },
+        { regexSource: 'example', regexFlags: '', matchSubstring: false, normalizeWhiteSpace: false, ignoreCase: true }
+      ]
+      expect(instance.send(:to_expected_text_values, items, ignore_case: true)).to eq(expected)
+    end
+
+    it 'throws an error when an item is not a string or regex' do
+      items = [1]
+      expect { instance.send(:to_expected_text_values, items) }.to(
+        raise_error(ArgumentError, 'Expected value provided to assertion to be a string or regex, got Integer')
+      )
+    end
+  end
+end


### PR DESCRIPTION
If you accidentally provide a non-string/non-regex value to an assertion like `expect(page.get_by_label('Calculated Total').to have_value(1.25)` then you get a cryptic error
```
     Playwright::Error:
       expectedText[0]: expected object, got null
```

This change will provide a more helpful error message like
```
    ArgumentError:
      Expected value provided to assertion to be a string or regex, got Integer
```