### PR TITLE
fix: eventual negated matchers failure messages

### DIFF
--- a/spec/integration/assertions_spec.rb
+++ b/spec/integration/assertions_spec.rb
@@ -823,6 +823,18 @@ RSpec.describe Playwright::LocatorAssertions, sinatra: true do
         expect(page.locator("button")).to not_be_enabled
       end
     end
+
+    it "should work eventually when negated" do
+      with_page do |page|
+        page.set_content("<button>Text</button>")
+        page.eval_on_selector("button", <<~JS)
+          button => setTimeout(() => {
+            button.setAttribute('disabled', '')
+          }, 700)
+        JS
+        expect(page.locator("button")).not_to be_enabled
+      end
+    end
   end
 
   describe "#to_be_editable" do
@@ -948,6 +960,19 @@ RSpec.describe Playwright::LocatorAssertions, sinatra: true do
         JS
 
         expect(page.locator("span")).to not_be_visible
+      end
+    end
+
+    it "should work eventually when negated" do
+      with_page do |page|
+        page.set_content("<div><span>Hello</span></div>")
+        page.eval_on_selector("span", <<~JS)
+          span => setTimeout(() => {
+            span.textContent = ''
+          }, 700)
+        JS
+
+        expect(page.locator("span")).not_to be_visible
       end
     end
   end


### PR DESCRIPTION
```
Failures:

1) Playwright::LocatorAssertions#to_be_visible should work eventually when negated
    Failure/Error: @failure_message.gsub("expected to", "not expected to")

    NoMethodError:
      undefined method `gsub` for nil
    # ./lib/playwright/test.rb:60 in `failure_message_when_negated`
....
```

This error occurs when a matcher is negated via RSpec and initially does not pass the assertion.

Example:

```ruby
expect(page.locator("span")).not_to be_visible
```

If the page initially has a visible `span`, then `Expect.new.call(...)` will not raise an `AssertionError` and `#matches?` will return `true`. 

But RSpec expects `matches?` to be `false` for negated matchers and calls `#failure_message_when_negated` in that case, and `@failure_message` wasn't set so it crashes.

### Solution
Use `#does_not_match?` to set `is_not` accurately

[RSpec docs](https://github.com/rspec/rspec-expectations/blob/838952dc1416c943e7933684c47249a77481e7f5/features/README.md#L44)

### Alternative Solution
One can use the negated matcher defined by playwright-ruby-client
```ruby
expect(page.locator("span")).to not_be_visible
```
but I think it would be nice to have the negated matchers work. 

The docs [mention](https://github.com/YusukeIwaki/playwright-ruby-client/blob/main/documentation/docs/api/locator_assertions.md?plain=1#L113) using
```ruby
expect(locator).not_to be_visible(timeout: nil, visible: nil)
```

but given this issue, if this isn't a valid fix, then I think it would be helpful to advise using `expect(...).to not_be_visible` instead