### PR TITLE
Convert time to milliseconds in `set_fixed_time`

### DIFF
--- a/lib/playwright/clock_impl.rb
+++ b/lib/playwright/clock_impl.rb
@@ -44,7 +44,7 @@ module Playwright
         { timeString: time }
       else
         if time.respond_to?(:utc)
-          { timeNumber: time.utc.to_i }
+          { timeNumber: time.utc.to_i * 1000 }
         else
           raise ArgumentError.new('time must be either integer, string or a Time object')
         end


### PR DESCRIPTION
Hello! 

First of all, thank you for this Gem, it's really useful!

I noticed that when I set the time of the clock using something like

```rb
# Ruby Code

page.driver.with_playwright_page do |page|
  page.clock.set_fixed_time(DateTime.parse("2022-01-01"))
end
```

then the browser is actually set to 1970.

```js
// Browser Console

new Date()
=> Tue Jan 20 1970 00:49:55 GMT+0100 (Central European Standard Time)

Date.now()
=> 1640995200
```

This is ALMOST correct, because we call this in Ruby:

```
DateTime.parse("2022-01-01").utc.to_i
=> 1640995200
```

But JavaScript is not counting seconds since 1970, but milliseconds. It needs to be multiplied with 1000, then it works. That's what this PR does.

Thank you for your consideration!