### PR TITLE
 Bugfix: page.context.enable_debug_console! does not work after Playwright internal change

### DIFF
--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -479,7 +479,7 @@ module Playwright
       #
       # So, launch inspector as Python app.
       # NOTE: This should be used only for Page#pause at this moment.
-      @channel.send_message_to_server('recorderEnable', language: :python)
+      @channel.send_message_to_server('enableRecorder', language: :python)
       @debug_console_enabled = true
     end
 

--- a/lib/playwright/channel_owners/browser_context.rb
+++ b/lib/playwright/channel_owners/browser_context.rb
@@ -479,7 +479,7 @@ module Playwright
       #
       # So, launch inspector as Python app.
       # NOTE: This should be used only for Page#pause at this moment.
-      @channel.send_message_to_server('recorderSupplementEnable', language: :python)
+      @channel.send_message_to_server('recorderEnable', language: :python)
       @debug_console_enabled = true
     end
 


### PR DESCRIPTION
This [commit](https://github.com/microsoft/playwright/commit/418d1c0c5557c5ccabd87c440146ef9c0c5987aa#diff-d7c041137e763edae5c4d18bc8ded9a1ac668078e310712341c444ef3aac423bR496) (which is [part](https://github.com/microsoft/playwright/blob/v1.48.2/packages/playwright-core/src/client/browserContext.ts#L496) of v1.48.2, the [`COMPATIBLE_PLAYWRIGHT_VERSION`](https://github.com/YusukeIwaki/playwright-ruby-client/blob/cc37b97e1dae429a81ce3b3540e0fb2930bfe7be/lib/playwright/version.rb#L5)) changed an internal API which broke `page.context.enable_debug_console!`