### PR TITLE
On AWS Lambda, node process become zombie process

### DIFF
--- a/lib/playwright/transport.rb
+++ b/lib/playwright/transport.rb
@@ -43,7 +43,7 @@ module Playwright
     # Terminate playwright-cli driver.
     def stop
       [@stdin, @stdout, @stderr].each { |io| io.close unless io.closed? }
-      @thread&.terminate
+      @thread&.join
     end
 
     # Start `playwright-cli run-driver`


### PR DESCRIPTION
Hello.

The current code calls terminate on the return value wait_thread of Open3.popen3. wait_thread represents the management thread for calling wait/waitpid. When terminate is called, wait/waitpid will no longer be invoked.

On some AWS Lambda and Docker containers, the process with process id 1 does not clean up the process table. As a result, the node.js process becomes a zombie process.

Referring to the Open3.popen3 call to set block arguments, it seems correct to call join for wait_thread.

https://github.com/ruby/open3/blob/b8909222051b4103a19eba19506727faece252e7/lib/open3.rb#L533-L547

I have created a file to check the behavior in a local Docker container, which is attached.

[reproduction.zip](https://github.com/user-attachments/files/20861693/reproduction.zip)

Builds a container image of the current code with build-arg APPLY_PATCH as an empty string. When executed, the node process becomes a zombie.
```shell
$ docker buildx build --build-arg APPLY_PATCH= --tag test .
$ docker container run --tty --rm test
USER         PID    PPID %CPU %MEM  STARTED     TIME STAT COMMAND
root           1       0 16.1  0.5 08:46:49 00:00:00 Ssl+ /usr/bin/ruby main.rb
root           7       1 44.1  0.0 08:46:50 00:00:00 Zl   [node] <defunct>
root          23       1  0.0  0.0 08:46:50 00:00:00 Z    [chrome_crashpad] <defunct>
root          25       1  0.0  0.0 08:46:50 00:00:00 Z    [chrome_crashpad] <defunct>
root          28       1  3.3  0.0 08:46:50 00:00:00 Z    [chrome] <defunct>
root          29       1  4.1  0.0 08:46:50 00:00:00 Z    [chrome] <defunct>
root         117       1  0.0  0.0 08:46:51 00:00:00 S+   sh -c ps -eo 'user,pid,ppid,%cpu,%mem,start,time,stat,command'
root         118     117  0.0  0.0 08:46:51 00:00:00 R+   ps -eo user,pid,ppid,%cpu,%mem,start,time,stat,command
```

If build-arg APPLY_PATCH is set to a value, it builds a container image with patch applied. The node process will not become a zombie when executed.
```shell
$ docker buildx build --build-arg APPLY_PATCH=1 --tag test .
$ docker container run --tty --rm test
USER         PID    PPID %CPU %MEM  STARTED     TIME STAT COMMAND
root           1       0 21.5  0.5 08:47:43 00:00:00 Ssl+ /usr/bin/ruby main.rb
root          23       1  0.0  0.0 08:47:44 00:00:00 Z    [chrome_crashpad] <defunct>
root          25       1  0.0  0.0 08:47:44 00:00:00 Z    [chrome_crashpad] <defunct>
root          28       1  7.0  0.0 08:47:44 00:00:00 Z    [chrome] <defunct>
root          29       1 10.5  0.0 08:47:44 00:00:00 Z    [chrome] <defunct>
root         117       1  0.0  0.0 08:47:45 00:00:00 S+   sh -c ps -eo 'user,pid,ppid,%cpu,%mem,start,time,stat,command'
root         118     117  0.0  0.0 08:47:45 00:00:00 R+   ps -eo user,pid,ppid,%cpu,%mem,start,time,stat,command
```
