### PR TITLE
Allow expect timeout configuration

### DIFF
--- a/lib/playwright/locator_assertions_impl.rb
+++ b/lib/playwright/locator_assertions_impl.rb
@@ -11,15 +11,15 @@ module Playwright
       end
     end
 
-    def initialize(locator, timeout, is_not, message)
+    def initialize(locator, default_expect_timeout, is_not, message)
       @locator = locator
-      @timeout = timeout
+      @default_expect_timeout = default_expect_timeout
       @is_not = is_not
       @custom_message = message
     end
 
     private def expect_impl(expression, expect_options, expected, message, title)
-      expect_options[:timeout] ||= 5000
+      expect_options[:timeout] ||= @default_expect_timeout
       expect_options[:isNot] = @is_not
       message.gsub!("expected to", "not expected to") if @is_not
       expect_options.delete(:useInnerText) if expect_options.key?(:useInnerText) && expect_options[:useInnerText].nil?
@@ -59,7 +59,7 @@ module Playwright
     private def _not # "not" is reserved in Ruby
       LocatorAssertionsImpl.new(
         @locator,
-        @timeout,
+        @default_expect_timeout,
         !@is_not,
         @message
       )

--- a/lib/playwright/page_assertions_impl.rb
+++ b/lib/playwright/page_assertions_impl.rb
@@ -11,16 +11,16 @@ module Playwright
       end
     end
 
-    def initialize(page, timeout, is_not, message)
+    def initialize(page, default_expect_timeout, is_not, message)
       @page = PlaywrightApi.unwrap(page)
       @locator = @page.locator(":root")
-      @timeout = timeout
+      @default_expect_timeout = default_expect_timeout
       @is_not = is_not
       @custom_message = message
     end
 
     private def expect_impl(expression, expect_options, expected, message, title)
-      expect_options[:timeout] ||= 5000
+      expect_options[:timeout] ||= @default_expect_timeout
       expect_options[:isNot] = @is_not
       message.gsub!("expected to", "not expected to") if @is_not
       expect_options.delete(:useInnerText) if expect_options.key?(:useInnerText) && expect_options[:useInnerText].nil?
@@ -60,7 +60,7 @@ module Playwright
     private def _not # "not" is reserved in Ruby
       PageAssertionsImpl.new(
         @page,
-        @timeout,
+        @default_expect_timeout,
         !@is_not,
         @message
       )

--- a/spec/integration/assertions_spec.rb
+++ b/spec/integration/assertions_spec.rb
@@ -301,6 +301,16 @@ RSpec.describe Playwright::LocatorAssertions, sinatra: true do
         expect {
           expect(locator).to contain_class('does-not-exist', timeout: 1000)
         }.to raise_error(/Expect "to_contain_class" with timeout 1000ms/)
+
+        ::Playwright::Test.with_timeout(500) do
+          expect {
+            expect(locator).to contain_class('does-not-exist')
+          }.to raise_error(/Expect "to_contain_class" with timeout 500ms/)
+
+          expect {
+            expect(locator).to contain_class('does-not-exist', timeout: 400)
+          }.to raise_error(/Expect "to_contain_class" with timeout 400ms/)
+        end
       end
     end
 


### PR DESCRIPTION
Resolves #332 

```
around do |example|
  ::Playwright::Test.with_timeout(500) # shorter expect timeout
    example.run
  end
end
```