### PR TITLE
Fix typo in Playwright inspector code example (`pagè` → `page`)

### DIFF
--- a/documentation/docs/article/guides/inspector.md
+++ b/documentation/docs/article/guides/inspector.md
@@ -15,7 +15,7 @@ playwright.chromium.launch(headless: false) do |browser|
     # This method call should be put just after creating BrowserContext.
     context.enable_debug_console!
 
-    page = context.new_pagè
+    page = context.new_page
     page.goto('http://example.com/')
     page.pause
   end


### PR DESCRIPTION
### Fix typo in Playwright inspector code example (`pagè` → `page`)

This PR corrects a small typo in the `Playwright inspector` documentation.

#### Before:

```ruby
page = context.new_pagè
```

#### After:

```ruby
page = context.new_page
```

This makes the example valid Ruby and avoids confusion for readers.