### PR TITLE
Fix Playwright.connect_to_browser_server to work

### DIFF
--- a/documentation/docs/article/guides/playwright_on_alpine_linux.md
+++ b/documentation/docs/article/guides/playwright_on_alpine_linux.md
@@ -25,6 +25,8 @@ However we may have trouble with bringing Playwright into:
 
 This article introduces a way to separate environments into client (for executing Playwright script) and server (for working with browsers). The main use-case assumes Docker (using Alpine Linux), however the way can be applied also into other use-cases.
 
+ref: https://playwright.dev/docs/docker#remote-connection
+
 ## Overview
 
 Playwright Ruby client is running on Alpine Linux. It just sends/receives JSON messages of Playwright-protocol via WebSocket.
@@ -33,47 +35,24 @@ Playwright server is running on a container of [official Docker image](https://h
 
 ![overview](https://user-images.githubusercontent.com/11763113/124934448-ad4d0700-e03f-11eb-942e-b9f3282bb703.png)
 
-### Playwright Server v.s. Browser Server
-
-Playwright provides two kind of methods to share the browser environments for clients.
-
-When you want to share only one browser environment, Browser server is suitable. This feature is officially supported in Playwright.
-
-- Server can be launched with [BrowserType#launchServer](https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server) instead of `BrowserType#launch`.
+- Server can be launched with `npx playwright run-server` CLI command.
 - Client can connect to server with [BrowserType#connect](https://playwright.dev/docs/api/class-browsertype#browser-type-connect). In playwright-ruby-client, `BrowserType#connect` and not implemented yet and use `Playwright#connect_to_browser_server()` instead.
-
-Another method is sharing all browser environment. This method is very simple, but not an official feature, and can be changed in future.
-
-- Server can be launched with `playwright run-server` (CLI command).
-- Client can connect to server with `Playwright.connect_to_playwright_server` instead of `Playwright.create`
-
-## Playwright server/client
-
-:::caution
-
-This method is no longer supported on Playwright driver >= 1.35. See [this issue](https://github.com/YusukeIwaki/playwright-ruby-client/issues/254) for detail, and use Browser server/client method instead.
-
-:::
 
 ### Client code
 
-Many example uses `Playwright#create`, which internally uses Pipe (stdin/stdout) transport for Playwright-protocol messaging. Instead, **just use `Playwright#connect_to_playwright_server(endpoint)`** for WebSocket transport.
+Many example uses `Playwright#create`, which internally uses Pipe (stdin/stdout) transport for Playwright-protocol messaging. Instead, **use `Playwright#connect_to_browser_server(endpoint)`** for WebSocket transport.
 
 ```ruby {3}
 require 'playwright'
 
-Playwright.connect_to_playwright_server('wss://example.com:8888/ws?browser=chromium') do |playwright|
-  playwright.chromium.launch do |browser|
-    page = browser.new_page
-    page.goto('https://github.com/microsoft/playwright')
-    page.screenshot(path: 'github-microsoft-playwright.png')
-  end
+Playwright.connect_to_browser_server('wss://example.com:8888/ws') do |browser|
+  page = browser.new_page
+  page.goto('https://github.com/microsoft/playwright')
+  page.screenshot(path: 'github-microsoft-playwright.png')
 end
 ```
 
 `wss://example.com:8888/ws` is an example of endpoint URL of the Playwright server. In local development environment, it is typically `"ws://127.0.0.1:#{port}/ws"`.
-
-Note that `?browser=chromium` is important for server to determine which browser to prepare.
 
 ### Server code
 
@@ -90,45 +69,6 @@ RUN npm install playwright && ./node_modules/.bin/playwright install
 ENV PORT 8888
 CMD ["./node_modules/.bin/playwright", "run-server", "--port", "$PORT", "--path", "/ws"]
 ```
-
-## Browser server/client
-
-### Client code
-
-Use `Playwright#connect_to_playwright_server` and pass the WebSocket URL for browser server.
-Note that this method requires a block with `Browser`, not `Playwright` or `BrowserType`.
-
-```ruby
-Playwright.connect_to_playwright_server(ws_url) do |browser|
-  page = browser.new_page
-  page.goto(...)
-  ...
-end
-```
-
-### Server code
-
-For instant use, `npx playwright launch-server --browser chromium` generates a WebSocket endpoint URL with a random path.
-
-More customization can be done by implementing JavaScript server like below:
-
-```js
-const playwright = require("playwright");
-
-option = {
-  channel: "chrome-canary",
-  headless: false,
-  port: 8080,
-  wsPath: "ws",
-};
-playwright.chromium.launchServer(option).then((server) => {
-  console.log(server.wsEndpoint());
-});
-```
-
-`port` and `wsPath` would be useful for generating static WebSocket endpoint URL.
-Other available options for `BrowserType#launchServer` can be found here:
-https://playwright.dev/docs/api/class-browsertype#browser-type-launch-server
 
 ## Debugging for connection
 
@@ -147,7 +87,7 @@ DEBUG=1 bundle exec ruby some-automation-with-playwright.rb
 Just set an environment variable `DEBUG=pw:*` or `DEBUG=pw:server`
 
 ```
-DEBUG=pw:* npx playwright launch-server --browser chromium
+DEBUG=pw:* npx playwright run-server --browser chromium
 ```
 
 See [the official documentation](https://playwright.dev/docs/debug/#verbose-api-logs) for details.

--- a/lib/playwright.rb
+++ b/lib/playwright.rb
@@ -159,8 +159,7 @@ module Playwright
       begin
         playwright = connection.initialize_playwright
         browser = playwright.send(:pre_launched_browser)
-        browser.send(:update_browser_type, playwright.chromium) # Just workaround for nil reference error.
-        browser.browser_type.send(:did_launch_browser, browser)
+        browser.send(:connect_to_browser_type, playwright.chromium, nil) # Just workaround for nil reference error.
         browser.send(:should_close_connection_on_close!)
         Execution.new(connection, PlaywrightApi.wrap(playwright), PlaywrightApi.wrap(browser))
       rescue

--- a/lib/playwright.rb
+++ b/lib/playwright.rb
@@ -178,7 +178,7 @@ module Playwright
     end
   end
 
-    # Connects to Playwright server, launched by `npx playwright launch-server chromium` or `playwright.chromium.launchServer()`
+  # Connects to Playwright server, launched by `npx playwright launch-server --browser _android` or `playwright._android.launchServer()`
   #
   # Playwright.connect_to_android_server('ws://....') do |browser|
   #   page = browser.new_page

--- a/lib/playwright/channel_owners/browser_type.rb
+++ b/lib/playwright/channel_owners/browser_type.rb
@@ -93,10 +93,6 @@ module Playwright
       context.send(:update_options, context_options: context_options, browser_options: browser_options)
     end
 
-    private def did_launch_browser(browser)
-      browser.send(:update_browser_type, self)
-    end
-
     private def update_with_playwright_selectors_options(options)
       selectors = @playwright&.selectors
       if selectors

--- a/lib/playwright/web_socket_client.rb
+++ b/lib/playwright/web_socket_client.rb
@@ -62,9 +62,12 @@ module Playwright
     STATE_CLOSING = 2
     STATE_CLOSED = 3
 
-    def initialize(url:, max_payload_size:)
+    def initialize(url:, max_payload_size:, headers:)
       @impl = DriverImpl.new(url)
       @driver = ::WebSocket::Driver.client(@impl, max_length: max_payload_size)
+      headers.each do |key, value|
+        @driver.set_header(key, value)
+      end
 
       setup
     end

--- a/lib/playwright/web_socket_transport.rb
+++ b/lib/playwright/web_socket_transport.rb
@@ -6,8 +6,9 @@ module Playwright
   # ref: https://github.com/microsoft/playwright-python/blob/master/playwright/_impl/_transport.py
   class WebSocketTransport
     # @param ws_endpoint [String] EndpointURL of WebSocket
-    def initialize(ws_endpoint:)
+    def initialize(ws_endpoint:, headers:)
       @ws_endpoint = ws_endpoint
+      @headers = headers
       @debug = ENV['DEBUG'].to_s == 'true' || ENV['DEBUG'].to_s == '1'
     end
 
@@ -63,6 +64,7 @@ module Playwright
       ws = WebSocketClient.new(
         url: @ws_endpoint,
         max_payload_size: 256 * 1024 * 1024, # 256MB
+        headers: @headers,
       )
       promise = Concurrent::Promises.resolvable_future
       ws.on_open do

--- a/spec/remote/connect_to_android_server_spec.rb
+++ b/spec/remote/connect_to_android_server_spec.rb
@@ -1,0 +1,35 @@
+require 'spec_helper'
+
+RSpec.describe 'Playwright.connect_to_android_server' do
+  around do |example|
+    unless ENV['PLAYWRIGHT_ANDROID_WS_ENDPOINT']
+      skip 'This spec requires PLAYWRIGHT_ANDROID_WS_ENDPOINT'
+    end
+
+    Playwright.connect_to_android_server(ENV['PLAYWRIGHT_ANDROID_WS_ENDPOINT']) do |android|
+      @android = android
+      example.run
+    end
+  end
+
+  def with_page(**kwargs, &block)
+    context = @android.launch_browser
+    page = context.pages.last
+    begin
+      block.call(page)
+    ensure
+      page.close unless page.closed?
+    end
+  end
+
+  it 'should work' do
+    puts "Connected to Android device: #{@android.model} (#{@android.serial})"
+    expect(@android.serial).not_to be_nil
+    expect(@android.model).not_to be_nil
+
+    with_page do |page|
+      page.goto('https://github.com/YusukeIwaki')
+      page.screenshot(path: 'screenshot.png')
+    end
+  end
+end


### PR DESCRIPTION
before fix

```
Failures:

  1) Playwright.connect_to_browser_server should work
     Failure/Error: browser.send(:update_browser_type, self)
     
     NoMethodError:
       undefined method `update_browser_type' for #<browser@d4d05723817f70d904f5e7c7ff80cf58>
     # ./lib/playwright/channel_owners/browser_type.rb:97:in `did_launch_browser'
```


Resolves #346