### PR TITLE
docs: add contributing guide reference

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,5 @@
+# Contributing
+
+Thanks for your interest in contributing to `playwright-ruby-client`!
+
+For development setup instructions and guidelines, please see [development/README.md](development/README.md).

--- a/README.md
+++ b/README.md
@@ -187,6 +187,10 @@ When `Playwright.connect_to_playwright_server` is used, playwright_cli_executabl
 
 For more detailed instraction, refer this article: https://playwright-ruby-client.vercel.app/docs/article/guides/playwright_on_alpine_linux
 
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup and contributing guidelines.
+
 ## License
 
 The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT).


### PR DESCRIPTION
## Summary
- mention CONTRIBUTING guide in README
- add a simple CONTRIBUTING.md pointing to development docs

## Testing
- `bundle exec rspec` *(fails: uninitialized constant Playwright::Test::PageAssertions)*

------
https://chatgpt.com/codex/tasks/task_e_68b87998d8308332ac2307583ed638a3