### PR TITLE
docs: clarify dev setup in development README

### DIFF
--- a/development/README.md
+++ b/development/README.md
@@ -1,6 +1,30 @@
 # development
 
-## (opt) Download driver
+## Prerequisites
+
+- Install Ruby dependencies via `bin/setup`:
+
+  ```sh
+  bin/setup
+  ```
+
+- Install Node.js and the Playwright driver. Use the version defined in [`lib/playwright/version.rb`](../lib/playwright/version.rb):
+
+  ```sh
+  VERSION=$(ruby -r "./lib/playwright/version" -e "puts Playwright::COMPATIBLE_PLAYWRIGHT_VERSION")
+  npm install "playwright@$VERSION"
+  ```
+  Avoid using `npx` to install Playwright because it always fetches the latest version.
+
+- Set the `PLAYWRIGHT_CLI_EXECUTABLE_PATH` environment variable. For example:
+
+  ```sh
+  export PLAYWRIGHT_CLI_EXECUTABLE_PATH="$(pwd)/node_modules/.bin/playwright"
+  ```
+
+## API generation and testing
+
+### (opt) Download driver
 
 Edit `development/CLI_VERSION` and then download the specific version of driver. It can be found in https://github.com/microsoft/playwright/actions/workflows/publish_canary.yml
 
@@ -12,13 +36,13 @@ Then, extract the driver zip file, and set `PLAYWRIGHT_CLI_EXECUTABLE_PATH`.
 
 Note that Playwright >= 1.43 doesn't include playwright.sh, and we have to set `$DRIVER_DOWNLOAD_PATH/node $DRIVER_DOWNLOAD_PATH/package/cli.js` into PLAYWRIGHT_CLI_EXECUTABLE_PATH or manually put https://github.com/microsoft/playwright/blob/v1.42.1/utils/build/run-driver-posix.sh into the root of the downloaded driver's dir.
 
-## Create/Update API definition
+### Create/Update API definition
 
 ```
 $PLAYWRIGHT_CLI_EXECUTABLE_PATH print-api-json | jq > development/api.json
 ```
 
-## Generate API codes
+### Generate API codes
 
 ```
 rm lib/playwright_api/*.rb
@@ -26,7 +50,7 @@ find documentation/docs -name "*.md" | grep -v documentation/docs/article/ | xar
 bundle exec ruby development/generate_api.rb
 ```
 
-## Test it
+### Test it
 
 ```
 $PLAYWRIGHT_CLI_EXECUTABLE_PATH install


### PR DESCRIPTION
## Summary
- describe running `bin/setup` for Ruby dependencies
- recommend installing Playwright via npm with version from `lib/playwright/version.rb` and avoid `npx`
- keep example for `PLAYWRIGHT_CLI_EXECUTABLE_PATH`

## Testing
- `bin/setup`
- `bundle exec rubocop` *(fails: 204 files inspected, 4892 offenses detected)*
- `bundle exec rspec` *(fails: NameError: uninitialized constant Playwright::Selectors)*

------
https://chatgpt.com/codex/tasks/task_e_68b879859cc8833292c5adde4180e798