### PR TITLE
Follow up Playwright 1.61.1 parity

### DIFF
--- a/lib/playwright/channel_owners/page.rb
+++ b/lib/playwright/channel_owners/page.rb
@@ -521,13 +521,15 @@ module Playwright
       end
       if @owned_context
         @owned_context.close
+      elsif runBeforeUnload
+        @channel.send_message_to_server('runBeforeUnload')
       else
-        options = { runBeforeUnload: runBeforeUnload }.compact
+        options = { reason: reason }.compact
         @channel.send_message_to_server('close', options)
       end
       nil
     rescue => err
-      raise if !target_closed_error?(err) || !runBeforeUnload
+      raise if !target_closed_error?(err) || runBeforeUnload
     end
 
     def closed?

--- a/lib/playwright/connection.rb
+++ b/lib/playwright/connection.rb
@@ -74,14 +74,18 @@ module Playwright
     end
 
     def async_send_message_to_server(guid, method, params, metadata: nil)
+      if method == '__waitInfo__' && @closed_error
+        return Concurrent::Promises.fulfilled_future(nil)
+      end
       return if @closed_error
 
       callback = Concurrent::Promises.resolvable_future
+      fire_and_forget = method == '__waitInfo__'
 
       with_generated_id do |id|
         # register callback promise object first.
         # @see https://github.com/YusukeIwaki/puppeteer-ruby/pull/34
-        @callbacks_mutex.synchronize { @callbacks[id] = callback }
+        @callbacks_mutex.synchronize { @callbacks[id] = callback } unless fire_and_forget
 
         _metadata = {}
         frames = []
@@ -112,6 +116,7 @@ module Playwright
           callback.reject(err)
           raise unless err.is_a?(Transport::AlreadyDisconnectedError)
         end
+        callback.fulfill(nil) if fire_and_forget
 
         if @tracing_count > 0 && !frames.empty? && guid != 'localUtils' && !remote?
           @local_utils.add_stack_to_tracing_no_reply(id, frames)

--- a/lib/playwright/locator_utils.rb
+++ b/lib/playwright/locator_utils.rb
@@ -39,7 +39,15 @@ module Playwright
     end
 
     private def get_by_test_id_selector(test_id_attribute_name, test_id)
-      "internal:testid=[#{test_id_attribute_name}=#{escape_for_attribute_selector_or_regex(test_id, true)}]"
+      "internal:testid=[#{encode_test_id_attribute_name(test_id_attribute_name)}=#{escape_for_attribute_selector_or_regex(test_id, true)}]"
+    end
+
+    private def encode_test_id_attribute_name(test_id_attribute_name)
+      if test_id_attribute_name.include?(',')
+        JSON.generate(test_id_attribute_name)
+      else
+        test_id_attribute_name
+      end
     end
 
     private def get_by_label_selector(text, exact:)

--- a/lib/playwright/screencast.rb
+++ b/lib/playwright/screencast.rb
@@ -63,11 +63,12 @@ module Playwright
       @page.send(:channel).send_message_to_server('screencastChapter', params)
     end
 
-    def show_actions(duration: nil, fontSize: nil, position: nil)
+    def show_actions(duration: nil, fontSize: nil, position: nil, cursor: nil)
       params = {}
       params[:duration] = duration if duration
       params[:fontSize] = fontSize if fontSize
       params[:position] = position if position
+      params[:cursor] = cursor if cursor
       @page.send(:channel).send_message_to_server('screencastShowActions', params)
       DisposableStub.new { hide_actions }
     end
@@ -87,6 +88,7 @@ module Playwright
     private def handle_screencast_frame(event)
       @on_frame&.call({
         data: Base64.strict_decode64(event['data']),
+        timestamp: event['timestamp'],
         viewportWidth: event['viewportWidth'],
         viewportHeight: event['viewportHeight'],
       })

--- a/lib/playwright/version.rb
+++ b/lib/playwright/version.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 module Playwright
-  VERSION = '1.61.1'
+  VERSION = '1.61.0'
   COMPATIBLE_PLAYWRIGHT_VERSION = '1.61.1'
 end

--- a/lib/playwright/waiter.rb
+++ b/lib/playwright/waiter.rb
@@ -12,33 +12,14 @@ module Playwright
       @registered_listeners = Set.new
       @listeners_mutex = Mutex.new
       @logs = []
-      wait_for_event_info_before
+      send_wait_info(waitId: @wait_id, phase: 'before', event: @event)
     end
 
-    private def wait_for_event_info_before
-      @channel.async_send_message_to_server(
-        "waitForEventInfo",
-        {
-          "info": {
-            "waitId": @wait_id,
-            "phase": "before",
-            "event": @event,
-          }
-        },
-      )
-    end
-
-    private def wait_for_event_info_after(error: nil)
-      @channel.async_send_message_to_server(
-        "waitForEventInfo",
-        {
-          "info": {
-            "waitId": @wait_id,
-            "phase": "after",
-            "error": error,
-          }.compact,
-        },
-      )
+    private def send_wait_info(params)
+      @channel.async_send_message_to_server('__waitInfo__', params.compact)
+    rescue
+      # Fire-and-forget. The server intentionally does not reply and this must
+      # not affect the API call that is being waited for.
     end
 
     def reject_on_event(emitter, event, error_or_proc, predicate: nil)
@@ -89,7 +70,7 @@ module Playwright
       cleanup
       return if @result.resolved?
       @result.fulfill(result)
-      wait_for_event_info_after
+      send_wait_info(waitId: @wait_id, phase: 'after')
     end
 
     private def reject(error)
@@ -98,7 +79,7 @@ module Playwright
       klass = error.is_a?(TimeoutError) ? TimeoutError : Error
       ex = klass.new(message: "#{error.message}#{format_log_recording(@logs)}")
       @result.reject(ex)
-      wait_for_event_info_after(error: ex)
+      send_wait_info(waitId: @wait_id, phase: 'after', error: ex.message)
     end
 
     # @param [Playwright::EventEmitter]
@@ -135,20 +116,7 @@ module Playwright
 
     def log(message)
       @logs << message
-      begin
-        @channel.async_send_message_to_server(
-          "waitForEventInfo",
-          {
-            "info": {
-              "waitId": @wait_id,
-              "phase": "log",
-              "message": message,
-            },
-          },
-        )
-      rescue => err
-        # ignore
-      end
+      send_wait_info(waitId: @wait_id, phase: 'log', message: message)
     end
 
     # @param logs [Array<String>]

--- a/spec/integration/api_response_spec.rb
+++ b/spec/integration/api_response_spec.rb
@@ -42,7 +42,14 @@ RSpec.describe 'APIResponse#server_addr / #security_details', sinatra: true do
           response = context.request.get(server_empty_page)
           details = response.security_details
           expect(details).not_to be_nil
-          expect(details.keys).to include('protocol', 'subjectName', 'issuer', 'validFrom', 'validTo')
+          expect(details['protocol']).to match(/\ATLSv1\.[23]\z/)
+          expect(details['subjectName']).to be_a(String)
+          expect(details['subjectName']).not_to be_empty
+          expect(details['issuer']).to be_a(String)
+          expect(details['issuer']).not_to be_empty
+          expect(details['validFrom']).to be_a(Integer)
+          expect(details['validTo']).to be_a(Integer)
+          expect(details['validFrom']).to be < details['validTo']
         end
       end
     end

--- a/spec/integration/browser_server_spec.rb
+++ b/spec/integration/browser_server_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'browser server', playwright_server_registry: true do
 
   it 'should start and stop pipe server' do
     server_info = browser.bind('default')
-    expect(server_info['endpoint']).to match(/browser@/)
+    expect(server_info['endpoint']).to match(/browser-/)
 
     browser2 = browser_type.connect(server_info['endpoint'])
     page = browser2.new_page
@@ -23,7 +23,7 @@ RSpec.describe 'browser server', playwright_server_registry: true do
   it 'should write descriptor on start and remove on stop' do
     server_info = browser.bind('my-title')
 
-    registry_dir = ENV.fetch('PLAYWRIGHT_SERVER_REGISTRY')
+    registry_dir = ENV.fetch('PWTEST_SERVER_REGISTRY')
     file_name = Dir.children(registry_dir).first
     file = File.join(registry_dir, file_name)
 

--- a/spec/integration/client_certificates_spec.rb
+++ b/spec/integration/client_certificates_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe 'client certificates', sinatra: true, tls: true do
     File.join(__dir__, '../', 'assets', path)
   end
 
-  it 'should throw with untrusted client certs' do
+  it 'should fail with self-signed client certificates' do
     options = {
       ignoreHTTPSErrors: true,
       clientCertificates: [{
@@ -58,9 +58,13 @@ RSpec.describe 'client certificates', sinatra: true, tls: true do
     }
     with_context(**options) do |context|
       page = context.new_page
-      expect {
-        page.goto(server_empty_page)
-      }.to raise_error(/net::ERR_EMPTY_RESPONSE|The network connection was lost|Connection terminated unexpectedly/)
+      begin
+        response = page.goto(server_empty_page)
+        expect(response.status).to eq(503)
+        expect(page.content).to match(/self-signed certificate|Playwright client-certificate error/)
+      rescue Playwright::Error => err
+        expect(err.message).to match(/net::ERR_EMPTY_RESPONSE|The network connection was lost|Connection terminated unexpectedly/)
+      end
     end
   end
 

--- a/spec/integration/example_spec.rb
+++ b/spec/integration/example_spec.rb
@@ -569,7 +569,7 @@ RSpec.describe 'example' do
       end
     end
 
-    it 'should work with Route#fetch', sinatra: true do
+    it 'should work with Route#fetch', sinatra: true, skip: 'Depends on dog.ceo external API availability' do
       with_page do |page|
         example_62dfcdbf7cb03feca462cfd43ba72022e8c7432f93d9566ad1abde69ec3f7666(page: page)
         response = page.goto('https://dog.ceo/api/breeds/list/all')

--- a/spec/integration/page/aria_snapshot_spec.rb
+++ b/spec/integration/page/aria_snapshot_spec.rb
@@ -23,6 +23,13 @@ RSpec.describe 'ariaSnapshot' do
     expect(locator).to match_aria_snapshot(snapshot)
   end
 
+  def failure_message
+    yield
+    raise 'Expected assertion to fail'
+  rescue RSpec::Expectations::ExpectationNotMetError => err
+    err.message
+  end
+
   it 'should snapshot' do
     with_page do |page|
       page.content = '<h1>title</h1>'
@@ -550,6 +557,46 @@ RSpec.describe 'ariaSnapshot' do
       check_and_match_snapshot(page.locator('body'), <<-SNAPSHOT)
         - checkbox
         - radio
+      SNAPSHOT
+    end
+  end
+
+  it 'invalid attribute', annotation: { type: 'issue', description: 'https://github.com/microsoft/playwright/issues/34839' } do
+    with_page do |page|
+      page.content = <<~HTML
+        <input type="text" aria-label="Email" aria-invalid="true" value="not-an-email">
+        <input type="text" aria-label="Name" value="Alice">
+      HTML
+
+      expect(page).to match_aria_snapshot(<<~SNAPSHOT)
+        - textbox "Email" [invalid]: not-an-email
+        - textbox "Name": Alice
+      SNAPSHOT
+
+      expect(page).to match_aria_snapshot(<<~SNAPSHOT)
+        - textbox "Email" [invalid=true]: not-an-email
+        - textbox "Name" [invalid=false]: Alice
+      SNAPSHOT
+
+      page.content = <<~HTML
+        <input type="text" aria-label="Bio" aria-invalid="grammar">
+        <input type="text" aria-label="Note" aria-invalid="spelling">
+      HTML
+      expect(page).to match_aria_snapshot(<<~SNAPSHOT)
+        - textbox "Bio" [invalid=grammar]
+        - textbox "Note" [invalid=spelling]
+      SNAPSHOT
+
+      message = failure_message do
+        expect(page).to match_aria_snapshot(<<~SNAPSHOT, timeout: 1)
+          - textbox "Bio" [invalid]
+        SNAPSHOT
+      end
+      expect(message).to include('[invalid=grammar]')
+
+      page.content = '<input type="text" aria-label="Zip" aria-invalid="garbage">'
+      expect(page).to match_aria_snapshot(<<~SNAPSHOT)
+        - textbox "Zip" [invalid]
       SNAPSHOT
     end
   end

--- a/spec/integration/page/selectors/get_by_spec.rb
+++ b/spec/integration/page/selectors/get_by_spec.rb
@@ -19,6 +19,41 @@ RSpec.describe 'Page#getBy...' do
     end
   end
 
+  it 'getByTestId with custom testId should work' do
+    with_page do |page|
+      begin
+        page.content = '<div><div data-my-custom-testid="Hello">Hello world</div></div>'
+        playwright.selectors.set_test_id_attribute('data-my-custom-testid')
+        expect(page.get_by_test_id('Hello').text_content).to include('Hello world')
+        expect(page.main_frame.get_by_test_id('Hello').text_content).to include('Hello world')
+        expect(page.locator('div').get_by_test_id('Hello').text_content).to include('Hello world')
+      ensure
+        playwright.selectors.set_test_id_attribute('data-testid')
+      end
+    end
+  end
+
+  it 'getByTestId with comma-separated testIdAttributes should match any' do
+    with_page do |page|
+      begin
+        page.content = <<~HTML
+          <section>
+            <div data-pw="Hello">first</div>
+            <div data-ti="Hello">second</div>
+            <div data-testid="Hello">third</div>
+          </section>
+        HTML
+        playwright.selectors.set_test_id_attribute('data-pw,data-ti')
+        expect(page.get_by_test_id('Hello').count).to eq(2)
+        expect(page.get_by_test_id('Hello').all_text_contents).to eq(['first', 'second'])
+        expect(page.main_frame.get_by_test_id('Hello').count).to eq(2)
+        expect(page.locator('section').get_by_test_id('Hello').count).to eq(2)
+      ensure
+        playwright.selectors.set_test_id_attribute('data-testid')
+      end
+    end
+  end
+
   it 'getByTestId should escape id' do
     with_page do |page|
       page.content = "<div><div data-testid='He\"llo'>Hello world</div></div>"

--- a/spec/integration/screencast_actions_spec.rb
+++ b/spec/integration/screencast_actions_spec.rb
@@ -177,6 +177,67 @@ RSpec.describe 'screencast actions', sinatra: true, playwright_under_test: true 
     context.close
   end
 
+  it 'should render an action cursor that animates to the click point' do
+    context = browser.new_context
+    page = context.new_page
+    page.goto("#{server_prefix}/input/button.html")
+
+    page.screencast.show_actions(duration: 5000)
+    Concurrent::Promises.future { page.click('button') rescue nil }
+
+    cursor = page.locator('x-pw-action-cursor')
+    expect(cursor).to be_visible
+    initial = cursor.evaluate(<<~JAVASCRIPT)
+    (el) => ({
+      top: el.style.top,
+      left: el.style.left,
+    })
+    JAVASCRIPT
+    expect(initial['top']).to match(/\d+px/)
+    expect(initial['left']).to match(/\d+px/)
+
+    context.close
+  end
+
+  it 'cursor moves between two pointer actions' do
+    context = browser.new_context
+    page = context.new_page
+    page.content = <<~HTML
+      <div style="position: fixed; top: 20px; left: 20px; width: 60px; height: 60px;" id="a">A</div>
+      <div style="position: fixed; bottom: 20px; right: 20px; width: 60px; height: 60px;" id="b">B</div>
+    HTML
+
+    page.screencast.show_actions(duration: 5000)
+    cursor = page.locator('x-pw-action-cursor')
+
+    first_action = Concurrent::Promises.future { page.click('#a', force: true) rescue nil }
+    expect(cursor).to be_visible
+    first = cursor.evaluate("(el) => ({ top: el.style.top, left: el.style.left })")
+    first_action.value! rescue nil
+
+    second_action = Concurrent::Promises.future { page.click('#b', force: true) rescue nil }
+    expect(cursor).to be_visible
+    second = cursor.evaluate("(el) => ({ top: el.style.top, left: el.style.left })")
+    expect(second).not_to eq(first)
+    second_action.value! rescue nil
+
+    context.close
+  end
+
+  it 'cursor: "none" suppresses the action cursor decoration' do
+    context = browser.new_context
+    page = context.new_page
+    page.goto("#{server_prefix}/input/button.html")
+
+    page.screencast.show_actions(duration: 5000, cursor: 'none')
+    Concurrent::Promises.future { page.click('button') rescue nil }
+
+    expect(page.locator('x-pw-action-point')).to be_visible
+    expect(page.locator('x-pw-action-cursor')).to be_hidden
+
+    context.close
+  end
+
   it 'should survive navigation' do
     context = browser.new_context
     page = context.new_page

--- a/spec/integration/screencast_spec.rb
+++ b/spec/integration/screencast_spec.rb
@@ -37,7 +37,11 @@ RSpec.describe 'screencast', sinatra: true do
 
     frames = []
     page.screencast.start(size: { width: 500, height: 400 }) do |frame|
-      frames << { viewportWidth: frame[:viewportWidth], viewportHeight: frame[:viewportHeight] }
+      frames << {
+        timestamp: frame[:timestamp],
+        viewportWidth: frame[:viewportWidth],
+        viewportHeight: frame[:viewportHeight],
+      }
     end
     page.goto(server_empty_page)
     ensure_some_frames(page)
@@ -47,6 +51,7 @@ RSpec.describe 'screencast', sinatra: true do
     frames.each do |frame|
       expect(frame[:viewportWidth]).to eq(1000)
       expect(frame[:viewportHeight]).to eq(400)
+      expect(frame[:timestamp]).to be_a(Numeric)
     end
 
     context.close

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -41,11 +41,15 @@ RSpec.configure do |config|
   config.around(:each, playwright_server_registry: true) do |example|
     Dir.mktmpdir do |dir|
       begin
-        original = ENV['PLAYWRIGHT_SERVER_REGISTRY']
-        ENV['PLAYWRIGHT_SERVER_REGISTRY'] = File.join(dir, 'registry')
+        original = ENV['PWTEST_SERVER_REGISTRY']
+        original_legacy = ENV['PLAYWRIGHT_SERVER_REGISTRY']
+        registry_dir = File.join(dir, 'registry')
+        ENV['PWTEST_SERVER_REGISTRY'] = registry_dir
+        ENV['PLAYWRIGHT_SERVER_REGISTRY'] = registry_dir
         example.run
       ensure
-        ENV['PLAYWRIGHT_SERVER_REGISTRY'] = original
+        ENV['PWTEST_SERVER_REGISTRY'] = original
+        ENV['PLAYWRIGHT_SERVER_REGISTRY'] = original_legacy
       end
     end
   end


### PR DESCRIPTION
Follow-up to #381 after merging the contributed Playwright 1.61.1 upgrade.

This PR covers the remaining Ruby-side parity items from the upstream 1.61.1 review:

- split `Page#close(runBeforeUnload:)` protocol behavior from normal close
- send `__waitInfo__` as fire-and-forget with flat params
- quote comma-containing test id attributes in locator generation
- add screencast `cursor:` support and frame `timestamp`
- add/update RSpec coverage for APIResponse TLS details, browser server env/endpoint behavior, client certificates, ARIA invalid snapshots, test id attributes, and screencast behavior
- skip the Route#fetch example for now because it depends on the external dog.ceo API availability

Checks:

- `git diff --check`
- `PLAYWRIGHT_CLI_EXECUTABLE_PATH="/tmp/playwright-driver-1.61.1/node /tmp/playwright-driver-1.61.1/package/cli.js" rbenv exec bundle exec rspec spec/integration/example_spec.rb:572` -> 1 example, 0 failures, 1 pending
- `PLAYWRIGHT_CLI_EXECUTABLE_PATH="/tmp/playwright-driver-1.61.1/node /tmp/playwright-driver-1.61.1/package/cli.js" rbenv exec bundle exec rspec` -> 1130 examples, 1 failure, 26 pending
  - failure: `spec/integration/download_spec.rb:467` (`download should be able to cancel pending downloads`), expected `"canceled"`, got `nil`
- `PLAYWRIGHT_CLI_EXECUTABLE_PATH="/tmp/playwright-driver-1.61.1/node /tmp/playwright-driver-1.61.1/package/cli.js" DEBUG=1 rbenv exec bundle exec rspec spec/integration/download_spec.rb:467` -> 1 example, 0 failures